### PR TITLE
Better photometry for SEDMv2 (and beyond...)

### DIFF
--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -54,7 +54,7 @@ from mirar.processors.zogy.zogy import (
 )
 
 load_raw = [
-    MultiExtParser(input_sub_dir="raw/mef/"),
+    MultiExtParser(input_sub_dir="raw/mef/", skip_first=True),
     ImageLoader(load_image=load_raw_sedmv2_image),
 ]
 

--- a/mirar/processors/utils/multi_ext_parser.py
+++ b/mirar/processors/utils/multi_ext_parser.py
@@ -32,11 +32,13 @@ class MultiExtParser(BaseImageProcessor):
         input_sub_dir: str = RAW_IMG_SUB_DIR,
         input_img_dir: str = base_raw_dir,
         load_image: Callable[[str], [np.ndarray, astropy.io.fits.Header]] = open_fits,
+        skip_first: bool = False,
     ):
         super().__init__()
         self.input_sub_dir = input_sub_dir
         self.input_img_dir = input_img_dir
         self.load_image = load_image
+        self.skip_first = skip_first
 
     def __str__(self):
         return (
@@ -63,7 +65,12 @@ class MultiExtParser(BaseImageProcessor):
             # zip hdr0's values and comments
             zipped = list(zip(hdr0.values(), hdr0.comments))
             # combining main header (hdr0) with extension header
-            for ext in range(1, num_ext):
+            if self.skip_first:
+                start = 2
+                logger.info("Ignoring first extension frame")
+            else:
+                start = 1
+            for ext in range(start, num_ext):
                 data = hdu[ext].data
                 hdrext = hdu[ext].header
 


### PR DESCRIPTION
This PR mainly changes the SEDMv2 pipeline, by:
- ensuring the IFU mask (made with `MaskPixels`) is carried down the pipeline, and incorporated into the later masks (like the one made by `Swarp`). This should reduce the chance that a half-covered-by-IFU source appears in `SExtractor` catalogs.
- adding the option to ignore the first frame in a MEF, since recent SEDMv2 data has faulty first frames

This PR also adds a new default behavior:
- when using PS1 as a photometric reference catalog, exclude PS1 sources flagged as "SATURATED". This change is built into `PhotCalibrator.calculate_zeropoint`. In the future, this behavior could be expanded to exclude any set of PS1 flags.

This PR closes #371.