### PR TITLE
MEF works for sedmv2

### DIFF
--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -4,7 +4,7 @@ Script containing the various
 lists which are used to build configurations for the
 :class:`~mirar.pipelines.sedmv2.sedmv2_pipeline.SEDMv2Pipeline`.
 """
-from mirar.paths import BASE_NAME_KEY, core_fields
+from mirar.paths import BASE_NAME_KEY, base_raw_dir, core_fields
 from mirar.pipelines.sedmv2.config import (
     psfex_config_path,
     sedmv2_cal_requirements,
@@ -54,7 +54,13 @@ from mirar.processors.zogy.zogy import (
 )
 
 load_raw = [
-    MultiExtParser(input_sub_dir="raw/mef/", skip_first=True),
+    MultiExtParser(
+        input_img_dir=base_raw_dir,
+        input_sub_dir="raw/mef/",
+        output_img_dir=base_raw_dir,
+        output_sub_dir="raw/",
+        skip_first=True,
+    ),
     ImageLoader(load_image=load_raw_sedmv2_image),
 ]
 


### PR DESCRIPTION
Last little modification to MultiExtParser to make sure it works for everyone. There was a path (`splitfile_path`) that wasn't utilizing the attribute introduced in the last PR (`self.output_img_dir`). To accommodate these changes, the call to MultiExtParser in `sedmv2/blocks.py` has been updated.