### PR TITLE
Various fixes for realtime

### DIFF
--- a/mirar/io.py
+++ b/mirar/io.py
@@ -93,17 +93,17 @@ def open_fits(path: str | Path) -> tuple[np.ndarray, fits.Header]:
     :param path: path of fits file
     :return: tuple containing image data and image header
     """
-    with fits.open(path) as img:
+    with fits.open(path, memmap=False) as img:
         hdu = img.pop(0)
         hdu.verify("silentfix+ignore")
         data = hdu.data
         header = hdu.header
 
-        if BASE_NAME_KEY not in header:
-            header[BASE_NAME_KEY] = Path(path).name
+    if BASE_NAME_KEY not in header:
+        header[BASE_NAME_KEY] = Path(path).name
 
-        if RAW_IMG_KEY not in header.keys():
-            header[RAW_IMG_KEY] = path
+    if RAW_IMG_KEY not in header.keys():
+        header[RAW_IMG_KEY] = path
 
     return data, header
 
@@ -138,7 +138,7 @@ def open_mef_fits(
     :return: tuple containing image data and image header
     """
     split_data, split_headers = [], []
-    with fits.open(path) as hdu:
+    with fits.open(path, memmap=False) as hdu:
         primary_header = hdu[0].header  # pylint: disable=no-member
         num_ext = len(hdu)
         for ext in range(1, num_ext):

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -380,7 +380,6 @@ load_unpacked = [
 dark_cal_all_boards = [
     ImageDebatcher(),
     ImageBatcher(["BOARD_ID", "EXPTIME", "SUBCOORD"]),
-    WriteMaskedCoordsToFile(output_dir="mask_raw"),
     DarkCalibrator(cache_sub_dir="calibration"),
     ImageSelector(("OBSTYPE", ["SCIENCE"])),
     ImageSaver(output_dir_name="darkcal"),
@@ -389,9 +388,9 @@ dark_cal_all_boards = [
 
 flat_cal_all_boards = [
     ImageBatcher(["BOARD_ID", "FILTER", "EXPTIME", "SUBCOORD"]),
-    SkyFlatCalibrator(flat_mask_key=FITS_MASK_KEY, cache_sub_dir="skycals"),
+    SkyFlatCalibrator(cache_sub_dir="skycals"),
     ImageSaver(output_dir_name="skyflatcal"),
-    NightSkyMedianCalibrator(flat_mask_key=FITS_MASK_KEY),
+    NightSkyMedianCalibrator(),
     ImageSaver(output_dir_name="skysub"),
 ]
 

--- a/mirar/pipelines/winter/fix_headers.py
+++ b/mirar/pipelines/winter/fix_headers.py
@@ -22,15 +22,13 @@ def fix_headers(logfile, night, keyword_list, sub_dir="raw"):
         image_filename = get_output_path(
             base_name=image_basename, dir_root=sub_dir, sub_dir="winter/" + night
         )
-        img_hdulist = fits.open(image_filename, "update")
-        img_header = img_hdulist[0].header
-        for key in keyword_list:
-            if obslog.loc[ind][key] is np.nan:
-                img_header[key] = ""
-            else:
-                img_header[key] = obslog.loc[ind][key]
-
-        img_hdulist.close()
+        with fits.open(image_filename, "update") as img_hdulist:
+            img_header = img_hdulist[0].header
+            for key in keyword_list:
+                if obslog.loc[ind][key] is np.nan:
+                    img_header[key] = ""
+                else:
+                    img_header[key] = obslog.loc[ind][key]
 
 
 if __name__ == "__main__":

--- a/mirar/pipelines/winter/load_winter_image.py
+++ b/mirar/pipelines/winter/load_winter_image.py
@@ -14,7 +14,7 @@ from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
 
 from mirar.data import Image
-from mirar.io import open_mef_fits, open_mef_image
+from mirar.io import open_fits, open_mef_fits, open_mef_image
 from mirar.paths import (
     BASE_NAME_KEY,
     COADD_KEY,
@@ -139,13 +139,11 @@ def load_proc_winter_image(path: str | Path) -> tuple[np.array, astropy.io.fits.
     Load proc image
     """
     logger.debug(f"Loading {path}")
-    with fits.open(path) as img:
-        data = img[0].data  # pylint: disable=no-member
-        header = img[0].header  # pylint: disable=no-member
-        if "weight" in path:
-            header["OBSTYPE"] = "weight"
+    data, header = open_fits(path)
+    if "weight" in path:
+        header["OBSTYPE"] = "weight"
 
-        header["FILTER"] = header["FILTERID"]
+    header["FILTER"] = header["FILTERID"]
 
     return data, header
 
@@ -157,22 +155,21 @@ def load_stacked_winter_image(
     Load proc image
     """
     logger.debug(f"Loading {path}")
-    with fits.open(path) as img:
-        data = img[0].data  # pylint: disable=no-member
-        header = img[0].header  # pylint: disable=no-member
-        if "weight" in path:
-            header["OBSTYPE"] = "weight"
+    data, header = open_fits(path)
 
-            header["OBSCLASS"] = "weight"
-            header["COADDS"] = 1
-            header["TARGET"] = "science"
-            header["CALSTEPS"] = ""
-            header["PROCFAIL"] = 1
-            header["RAWPATH"] = ""
-            header["BASENAME"] = os.path.basename(path)
-            header["TARGNAME"] = "weight"
-        if "UTCTIME" not in header.keys():
-            header["UTCTIME"] = "2023-06-14T00:00:00"
+    if "weight" in path:
+        header["OBSTYPE"] = "weight"
+
+        header["OBSCLASS"] = "weight"
+        header["COADDS"] = 1
+        header["TARGET"] = "science"
+        header["CALSTEPS"] = ""
+        header["PROCFAIL"] = 1
+        header["RAWPATH"] = ""
+        header["BASENAME"] = os.path.basename(path)
+        header["TARGNAME"] = "weight"
+    if "UTCTIME" not in header.keys():
+        header["UTCTIME"] = "2023-06-14T00:00:00"
 
     return data, header
 

--- a/mirar/processors/photcal.py
+++ b/mirar/processors/photcal.py
@@ -227,9 +227,16 @@ class PhotCalibrator(BaseProcessorWithCrossMatch):
             ref_cat, _, cleaned_img_cat = self.setup_catalogs(image)
 
             fwhm_med, _, fwhm_std, med_fwhm_pix, _, _ = get_fwhm(cleaned_img_cat)
-            image["FWHM_MED"] = fwhm_med
-            image["FWHM_STD"] = fwhm_std
-            image["FWHM_PIX"] = med_fwhm_pix
+
+            header_map = {
+                "FWHM_MED": fwhm_med,
+                "FWHM_STD": fwhm_std,
+                "FWHM_PIX": med_fwhm_pix,
+            }
+            for key, value in header_map.items():
+                if np.isnan(value):
+                    value = -999.0
+                image.header[key] = value
 
             if len(ref_cat) == 0:
                 err = "No sources found in reference catalog"

--- a/mirar/utils/ldac_tools.py
+++ b/mirar/utils/ldac_tools.py
@@ -87,7 +87,7 @@ def save_table_as_ldac(tbl: astropy.table.Table, file_path: str, **kwargs):
         Keyword arguments to pass to hdulist.writeto
     """
     hdulist = convert_table_to_ldac(tbl)
-    hdulist.writeto(file_path, **kwargs)
+    hdulist.writeto(file_path, overwrite=True, **kwargs)
 
 
 def get_table_from_ldac(file_path: str | Path, frame: int = 1) -> astropy.table.Table:


### PR DESCRIPTION
Inspired by the not very impressive processing success rate, this PR introduces small fixes to address various errors.

It avoids putting nan FWHMs in headers, avoids using mmaps, removes the poorly-performing "mask" processor, improves the monitoring log and uses overwrite for ldac tables. 