### PR TITLE
Add source table loader/writer

### DIFF
--- a/mirar/data/source_data.py
+++ b/mirar/data/source_data.py
@@ -58,6 +58,9 @@ class SourceTable(DataBlock):
         """
         return self.metadata.keys()
 
+    def __len__(self):
+        return len(self.source_list)
+
 
 class SourceBatch(DataBatch):
     """

--- a/mirar/pipelines/summer/blocks.py
+++ b/mirar/pipelines/summer/blocks.py
@@ -48,7 +48,7 @@ from mirar.processors.photcal import PhotCalibrator
 from mirar.processors.photometry.aperture_photometry import CandidateAperturePhotometry
 from mirar.processors.photometry.psf_photometry import CandidatePSFPhotometry
 from mirar.processors.reference import ProcessReference
-from mirar.processors.sources import DataframeWriter
+from mirar.processors.sources import JsonSourceWriter
 from mirar.processors.sources.source_detector import SourceDetector
 from mirar.processors.sources.utils import RegionsWriter
 from mirar.processors.sqldatabase.database_exporter import DatabaseImageExporter
@@ -255,7 +255,7 @@ extract_candidates = [
         bkg_out_diameters=[40, 100],
         col_suffix_list=["", "big"],
     ),
-    DataframeWriter(output_dir_name="candidates"),
+    JsonSourceWriter(output_dir_name="candidates"),
 ]
 
 imsub = subtract + export_diff_to_db + extract_candidates  # FIXME

--- a/mirar/pipelines/winter/winter_pipeline.py
+++ b/mirar/pipelines/winter/winter_pipeline.py
@@ -19,6 +19,7 @@ from mirar.pipelines.winter.blocks import (
     load_stack,
     load_test,
     only_ref,
+    photcal,
     realtime,
     reduce,
     refbuild,
@@ -58,6 +59,7 @@ class WINTERPipeline(Pipeline):
         "realtime": realtime,
         "test": load_test + realtime,
         "buildtest": build_test,
+        "photcal": photcal,
     }
 
     non_linear_level = 65535

--- a/mirar/pipelines/wirc/blocks.py
+++ b/mirar/pipelines/wirc/blocks.py
@@ -56,7 +56,7 @@ from mirar.processors.photometry.psf_photometry import (
 )
 from mirar.processors.reference import ProcessReference
 from mirar.processors.sky import NightSkyMedianCalibrator
-from mirar.processors.sources import CandidateNamer, DataframeWriter, SourceDetector
+from mirar.processors.sources import CandidateNamer, JsonSourceWriter, SourceDetector
 from mirar.processors.sources.source_table_builder import ForcedPhotometryCandidateTable
 from mirar.processors.sources.utils import RegionsWriter
 from mirar.processors.utils import (
@@ -225,10 +225,10 @@ process_candidates = [
         bkg_out_diameters=[40, 100],
         col_suffix_list=["", "big"],
     ),
-    DataframeWriter(output_dir_name="candidates"),
+    JsonSourceWriter(output_dir_name="candidates"),
     XMatch(catalog=TMASS(num_sources=3, search_radius_arcmin=0.5)),
     XMatch(catalog=PS1(num_sources=3, search_radius_arcmin=0.5)),
-    DataframeWriter(output_dir_name="kowalski"),
+    JsonSourceWriter(output_dir_name="kowalski"),
     DatabaseHistoryImporter(
         crossmatch_radius_arcsec=2.0,
         time_field_name="jd",
@@ -253,7 +253,7 @@ process_candidates = [
         schema_path=wirc_candidate_schema_path,
         duplicate_protocol="replace",
     ),
-    DataframeWriter(output_dir_name="dbop"),
+    JsonSourceWriter(output_dir_name="dbop"),
     # EdgeCandidatesMask(edge_boundary_size=100)
     # FilterCandidates(),
 ]

--- a/mirar/processors/sources/__init__.py
+++ b/mirar/processors/sources/__init__.py
@@ -2,8 +2,8 @@
 Central module for candidate detection and extraction.
 """
 from mirar.processors.sources.candidate_filter import BaseSourceFilter
-from mirar.processors.sources.dataframe_writer import DataframeWriter
 from mirar.processors.sources.edge_mask import EdgeSourcesMask
+from mirar.processors.sources.json_exporter import JsonSourceWriter
 from mirar.processors.sources.namer import CandidateNamer
 from mirar.processors.sources.source_detector import SourceDetector
 from mirar.processors.sources.source_table_builder import (

--- a/mirar/processors/sources/__init__.py
+++ b/mirar/processors/sources/__init__.py
@@ -4,6 +4,7 @@ Central module for candidate detection and extraction.
 from mirar.processors.sources.candidate_filter import BaseSourceFilter
 from mirar.processors.sources.edge_mask import EdgeSourcesMask
 from mirar.processors.sources.json_exporter import JsonSourceWriter
+from mirar.processors.sources.json_loader import JsonSourceLoader
 from mirar.processors.sources.namer import CandidateNamer
 from mirar.processors.sources.source_detector import SourceDetector
 from mirar.processors.sources.source_table_builder import (

--- a/mirar/processors/sources/json_exporter.py
+++ b/mirar/processors/sources/json_exporter.py
@@ -88,6 +88,6 @@ class JsonSourceWriter(BaseSourceProcessor):
 
             logger.debug(f"Writing dataframe to {json_path}")
 
-            save_source_table_to_json(source_table, json_path)
+            save_source_table_to_json(source_list, json_path)
 
         return batch

--- a/mirar/processors/sources/json_loader.py
+++ b/mirar/processors/sources/json_loader.py
@@ -1,0 +1,77 @@
+"""
+Module with classes to read a source table from a json file
+"""
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from mirar.data import SourceBatch, SourceTable
+from mirar.paths import base_output_dir, get_output_dir
+from mirar.processors.base_processor import BaseSourceProcessor
+from mirar.processors.sources.json_exporter import (
+    DATA_JSON_KEY,
+    METADATA_JSON_KEY,
+    SOURCE_SUFFIX,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def load_source_table_from_json(json_path: Path) -> SourceTable:
+    """
+    Function to load a source table from a json file
+
+    :param json_path: Path to the json file
+    :return: JSON file as a SourceTable
+    """
+    with open(json_path, "r", encoding="utf8") as json_f:
+        res = json.load(json_f)
+    metadata = res[METADATA_JSON_KEY]
+    data = pd.read_json(res[DATA_JSON_KEY])
+    return SourceTable(data, metadata)
+
+
+class JsonSourceLoader(BaseSourceProcessor):
+    """
+    Class to write a candidate table to a pandas dataframe
+    """
+
+    base_key = "JSONLOAD"
+
+    def __init__(
+        self,
+        input_dir_name: Optional[str] = None,
+        input_dir: str | Path = base_output_dir,
+    ):
+        super().__init__()
+        self.input_dir_name = input_dir_name
+        self.input_dir = Path(input_dir)
+
+    def __str__(self) -> str:
+        return f"Processor to load sources from json files in {self.input_dir_name} . "
+
+    def _apply_to_sources(
+        self,
+        batch: SourceBatch,
+    ) -> SourceBatch:
+        input_dir = get_output_dir(
+            dir_root=self.input_dir_name,
+            sub_dir=self.night_sub_dir,
+            output_dir=self.input_dir,
+        )
+        input_dir.mkdir(parents=True, exist_ok=True)
+
+        new_batch = SourceBatch()
+
+        source_tables = list(input_dir.glob(f"*{SOURCE_SUFFIX}"))
+        for source_path in source_tables:
+            source_table = load_source_table_from_json(source_path)
+            if len(source_table) > 0:
+                new_batch.append(source_table)
+            else:
+                logger.warning(f"Empty source table in {source_path}")
+
+        return new_batch

--- a/mirar/processors/sources/namer.py
+++ b/mirar/processors/sources/namer.py
@@ -107,7 +107,7 @@ class CandidateNamer(BaseDatabaseProcessor, BaseSourceProcessor):
             last_name_letters = last_name[len(self.base_name) + 2 :]
             new_name_letters = self.increment_string(last_name_letters)
             name = self.base_name + str(cand_year) + new_name_letters
-        logger.debug(name)
+        logger.debug(f"Assigning name: {name}")
         return name
 
     def is_detected_previously(self, ra_deg: float, dec_deg: float) -> tuple[bool, str]:
@@ -127,7 +127,6 @@ class CandidateNamer(BaseDatabaseProcessor, BaseSourceProcessor):
             dec=dec_deg,
             crossmatch_radius_arcsec=self.crossmatch_radius_arcsec,
         )  # [0]
-        logger.info(name)
         return len(name) > 0, name
 
     def _apply_to_sources(

--- a/mirar/processors/sources/source_detector.py
+++ b/mirar/processors/sources/source_detector.py
@@ -219,8 +219,9 @@ class SourceDetector(BaseSourceGenerator):
 
             metadata = {}
 
-            for key in core_fields:
-                metadata[key] = image[key]
+            for key in image.keys():
+                if key != "COMMENT":
+                    metadata[key] = image[key]
 
             if len(srcs_table) == 0:
                 msg = f"No sources found in image {image[BASE_NAME_KEY]}"


### PR DESCRIPTION
You can now write source tables to json, or load them from json. This replaces the dataframe writer completely, with the new functionality of metadata preservation.