### PR TITLE
Update SEDMv2 with aperature photometry

### DIFF
--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -107,16 +107,20 @@ reduce = [
     ),
 ]
 
-resample = [
+resample_stellar = [
+    # ImageDebatcher(),
+    # reaches for files coming from the same object
+    # (note there can be more tha one MEF file per stellar object!)
+    # ImageBatcher(split_key="OBJECTID"),
     Swarp(
         swarp_config_path=swarp_config_path,
         include_scamp=False,
         combine=False,
         calculate_dims_in_swarp=True,
     ),
-    # ImageSaver(
-    #    output_dir_name="resampled", write_mask=True
-    # ),  # pylint: disable=duplicate-code
+    ImageSaver(
+        output_dir_name="resampled", write_mask=True
+    ),  # pylint: disable=duplicate-code
 ]
 
 calibrate = [
@@ -133,36 +137,33 @@ calibrate = [
     HeaderEditor(edit_keys="procflag", values=1),
 ]
 
-process = reduce + resample + calibrate
-
-
 # stellar --
 
 parse_stellar = [ImageSelector(("SOURCE", ["stellar", "None"]))]
 
 # process_stellar = parse_stellar + process
-process_stellar = process
+process_stellar = reduce + resample_stellar + calibrate
 
 image_photometry = [  # imported from wirc/blocks.py
     # ImageSelector(("OBSTYPE", "SCIENCE")),
     ImageDebatcher(),
     ImageAperturePhotometry(
-        aper_diameters=[8, 16],
-        bkg_in_diameters=[20, 25],
-        bkg_out_diameters=[30, 40],
+        aper_diameters=[5, 10],
+        bkg_in_diameters=[6, 11],
+        bkg_out_diameters=[11, 16],
         col_suffix_list=None,  # [""],
         phot_cutout_size=100,
         target_ra_key="OBJRAD",
         target_dec_key="OBJDECD",
         zp_colname="ZP_AUTO",
     ),
-    Sextractor(**sextractor_reference_config, output_sub_dir="psf", cache=False),
-    PSFex(config_path=psfex_config_path, output_sub_dir="psf", norm_fits=True),
-    ImagePSFPhotometry(
-        target_ra_key="OBJRAD",
-        target_dec_key="OBJDECD",
-        zp_colname="ZP_AUTO",
-    ),
+    # Sextractor(**sextractor_reference_config, output_sub_dir="psf", cache=False),
+    # PSFex(config_path=psfex_config_path, output_sub_dir="psf", norm_fits=True),
+    # ImagePSFPhotometry(
+    #     target_ra_key="OBJRAD",
+    #     target_dec_key="OBJDECD",
+    #     zp_colname="ZP_AUTO",
+    # ),
     ImageSaver(output_dir_name="photometry"),
 ]
 

--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -91,10 +91,10 @@ reduce = [
     ImageSaver(output_dir_name="detrend", write_mask=True),
     AstrometryNet(
         output_sub_dir="a-net",
-        scale_bounds=(0.1667, 0.0333),
+        scale_bounds=(0.08333333, 0.11666667),
         scale_units="degw",
         downsample=2,
-        timeout=900,
+        timeout=60,
     ),
     ImageSaver(output_dir_name="a-net-solved", write_mask=True),
     Sextractor(
@@ -145,9 +145,9 @@ process_stellar = reduce + resample_stellar + calibrate
 image_photometry = [  # imported from wirc/blocks.py
     # ImageSelector(("OBSTYPE", "SCIENCE")),
     ImageAperturePhotometry(
-        aper_diameters=[16, 31],
-        bkg_in_diameters=[19, 34],
-        bkg_out_diameters=[34, 50],
+        aper_diameters=[6, 16],
+        bkg_in_diameters=[9, 19],
+        bkg_out_diameters=[16, 34],
         col_suffix_list=None,  # [""],
         phot_cutout_size=100,
         target_ra_key="OBJRAD",

--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -144,7 +144,6 @@ process_stellar = reduce + resample_stellar + calibrate
 
 image_photometry = [  # imported from wirc/blocks.py
     # ImageSelector(("OBSTYPE", "SCIENCE")),
-    ImageDebatcher(),
     ImageAperturePhotometry(
         aper_diameters=[16, 31],
         bkg_in_diameters=[19, 34],

--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -5,12 +5,11 @@ lists which are used to build configurations for the
 :class:`~mirar.pipelines.sedmv2.sedmv2_pipeline.SEDMv2Pipeline`.
 """
 from mirar.paths import BASE_NAME_KEY, core_fields
-from mirar.pipelines.sedmv2.config import (
+from mirar.pipelines.sedmv2.config import (  # sextractor_reference_config,
     psfex_config_path,
     sedmv2_mask_path,
     sextractor_astrometry_config,
     sextractor_photometry_config,
-    sextractor_reference_config,
     swarp_config_path,
 )
 from mirar.pipelines.sedmv2.generator import (
@@ -31,9 +30,8 @@ from mirar.processors.photometry.aperture_photometry import (
     CandidateAperturePhotometry,
     ImageAperturePhotometry,
 )
-from mirar.processors.photometry.psf_photometry import (
+from mirar.processors.photometry.psf_photometry import (  # ImagePSFPhotometry,
     CandidatePSFPhotometry,
-    ImagePSFPhotometry,
 )
 from mirar.processors.reference import ProcessReference
 from mirar.processors.utils import (
@@ -148,9 +146,9 @@ image_photometry = [  # imported from wirc/blocks.py
     # ImageSelector(("OBSTYPE", "SCIENCE")),
     ImageDebatcher(),
     ImageAperturePhotometry(
-        aper_diameters=[5, 10],
-        bkg_in_diameters=[6, 11],
-        bkg_out_diameters=[11, 16],
+        aper_diameters=[16, 31],
+        bkg_in_diameters=[19, 34],
+        bkg_out_diameters=[34, 50],
         col_suffix_list=None,  # [""],
         phot_cutout_size=100,
         target_ra_key="OBJRAD",

--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -144,19 +144,20 @@ parse_stellar = [ImageSelector(("SOURCE", ["stellar", "None"]))]
 process_stellar = process
 
 image_photometry = [  # imported from wirc/blocks.py
-    # ImageSelector(("SOURCE", "stellar")),
+    # ImageSelector(("OBSTYPE", "SCIENCE")),
+    ImageDebatcher(),
     ImageAperturePhotometry(
-        aper_diameters=[16],
-        bkg_in_diameters=[25],
-        bkg_out_diameters=[40],
-        col_suffix_list=[""],
+        aper_diameters=[8, 16],
+        bkg_in_diameters=[20, 25],
+        bkg_out_diameters=[30, 40],
+        col_suffix_list=None,  # [""],
         phot_cutout_size=100,
         target_ra_key="OBJRAD",
         target_dec_key="OBJDECD",
         zp_colname="ZP_AUTO",
     ),
-    Sextractor(**sextractor_reference_config, output_sub_dir="subtract", cache=False),
-    PSFex(config_path=psfex_config_path, output_sub_dir="photometry", norm_fits=True),
+    Sextractor(**sextractor_reference_config, output_sub_dir="psf", cache=False),
+    PSFex(config_path=psfex_config_path, output_sub_dir="psf", norm_fits=True),
     ImagePSFPhotometry(
         target_ra_key="OBJRAD",
         target_dec_key="OBJDECD",

--- a/mirar/pipelines/sedmv2/load_sedmv2_image.py
+++ b/mirar/pipelines/sedmv2/load_sedmv2_image.py
@@ -69,14 +69,8 @@ def clean_science_header(
     # header["BZERO"] = 0
 
     if not isinstance(header["OBJECTID"], str):
-        if "GWLIb" in header["QCOMMENT"]:
-            header["OBJRAD"] = 229.9802519789
-            header["OBJDECD"] = -25.0067323323
-            header["OBJECTID"] = "GWLib"
-        elif "SDSSdC11h26m33.94s+04d41m37.61s" in header["QCOMMENT"]:
-            header["OBJECTID"] = "SDSSdC11h26m33.94s+04d41m37.61s"
-        elif isinstance(header["QCOMMENT"], str):
-            header["OBJECTID"] = header["QCOMMENT"]
+        if isinstance(header["QCOMMENT"], str):
+            header["OBJECTID"] = header["QCOMMENT"].split("_")[0]
 
     if not "EXPTIME" in header:
         header["EXPTIME"] = header["EXPOSURE"]

--- a/mirar/pipelines/sedmv2/load_sedmv2_image.py
+++ b/mirar/pipelines/sedmv2/load_sedmv2_image.py
@@ -57,6 +57,28 @@ def clean_science_header(header: fits.Header) -> fits.Header:
     header["COADDS"] = 1
     # header["BZERO"] = 0
 
+    if isinstance(header["OBJECTID"], str):
+        if "GWLIb" in header["QCOMMENT"]:
+            print("changing OBJ coord in header for GW Lib.")
+            header["OBJRAD"] = 229.9802519789
+            header["OBJDECD"] = -25.0067323323
+            print("changing OBJECTID in header for GWLib.")
+            header["OBJECTID"] = "GWLib"
+        elif "SDSSdC11h26m33.94s+04d41m37.61s" in header["QCOMMENT"]:
+            print("changing OBJECTID in header for SDSSdC11h26m33.94s+04d41m37.61s.")
+            header["OBJECTID"] = "SDSSdC11h26m33.94s+04d41m37.61s"
+    else:
+        print("Not updating any header info in this image.")
+
+    if not "EXPTIME" in header:
+        header["EXPTIME"] = header["EXPOSURE"]
+
+    # print("changing OBJ coord in header for Zach's obkect!")
+    # header["OBJRAD"] = 296.13913
+    # header["OBJDECD"] = 45.948832499999995
+    # header["OBJRAD"] = 296.20914375
+    # header["OBJDECD"] = 45.9812411111111
+
     # times
     # orig_dateobs = header["DATE-OBS"]
     # header["DATE-OBS"] = convert_to_UTC(orig_dateobs) # this is the date of entire obs

--- a/mirar/pipelines/sedmv2/sedmv2_pipeline.py
+++ b/mirar/pipelines/sedmv2/sedmv2_pipeline.py
@@ -12,7 +12,6 @@ from mirar.pipelines.base_pipeline import Pipeline
 from mirar.pipelines.sedmv2.blocks import (
     image_photometry,
     load_raw,
-    process,
     process_stellar,
     process_transient,
 )
@@ -34,7 +33,6 @@ class SEDMv2Pipeline(Pipeline):
     non_linear_level = 30000  # no idea, for pylint
     default_cal_requirements = sedmv2_cal_requirements
     all_pipeline_configurations = {
-        "default": load_raw + process,
         "default_stellar": load_raw + process_stellar + image_photometry,
         "default_transient": load_raw + process_transient,  # +imsub,
     }

--- a/mirar/pipelines/sedmv2/sedmv2_pipeline.py
+++ b/mirar/pipelines/sedmv2/sedmv2_pipeline.py
@@ -33,6 +33,7 @@ class SEDMv2Pipeline(Pipeline):
     non_linear_level = 30000  # no idea, for pylint
     default_cal_requirements = sedmv2_cal_requirements
     all_pipeline_configurations = {
+        "default": load_raw + process_stellar,
         "default_stellar": load_raw + process_stellar + image_photometry,
         "default_transient": load_raw + process_transient,  # +imsub,
     }

--- a/mirar/processors/photometry/aperture_photometry.py
+++ b/mirar/processors/photometry/aperture_photometry.py
@@ -20,8 +20,6 @@ from mirar.processors.photometry.base_photometry import (
     BaseImagePhotometry,
 )
 
-logger = logging.getLogger(__name__)
-
 
 class CandidateAperturePhotometry(BaseCandidatePhotometry):
     """

--- a/mirar/processors/photometry/aperture_photometry.py
+++ b/mirar/processors/photometry/aperture_photometry.py
@@ -130,33 +130,18 @@ class ImageAperturePhotometry(BaseImagePhotometry):
         for image in batch:
             image_cutout, unc_image_cutout = self.generate_cutouts(image)
 
-            imagename, unc_imagename = self.get_image_filenames(image)
-            cutout_dir = "/Users/benjaminroulston/Documents/DATA_NOT_FOR_DROPBOX/SEDMv2/OUTPUT_DATA/image_cutouts/"
-            np.savetxt(
-                f"{cutout_dir}{imagename.name.replace('.fits', '_cutout.txt')}",
-                image_cutout,
-            )
-            np.savetxt(
-                f"{cutout_dir}{unc_imagename.name.replace('.fits.unc',\
-                                                          '_unc_cutout.txt')}",
-                unc_image_cutout,
-            )
-
             fluxes, fluxuncs = self.aperture_photometer.perform_photometry(
                 image_cutout, unc_image_cutout
             )
 
             for ind, flux in enumerate(fluxes):
-                try:
-                    fluxunc = fluxuncs[ind]
-                    suffix = self.col_suffix_list[ind]
-                    image[f"fluxap{suffix}"] = flux
-                    image[f"fluxunc{suffix}"] = fluxunc
-                    image[f"magap{suffix}"] = float(
-                        image[self.zp_colname]
-                    ) - 2.5 * np.log10(flux)
-                    image[f"magerrap{suffix}"] = 1.086 * fluxunc / flux
-                except ValueError:
-                    logger.error(f"Aperture photometry failed on: {imagename=}")
+                fluxunc = fluxuncs[ind]
+                suffix = self.col_suffix_list[ind]
+                image[f"fluxap{suffix}"] = flux
+                image[f"fluxunc{suffix}"] = fluxunc
+                image[f"magap{suffix}"] = float(
+                    image[self.zp_colname]
+                ) - 2.5 * np.log10(flux)
+                image[f"magerrap{suffix}"] = 1.086 * fluxunc / flux
 
         return batch

--- a/mirar/processors/photometry/aperture_photometry.py
+++ b/mirar/processors/photometry/aperture_photometry.py
@@ -12,7 +12,6 @@ from mirar.paths import (
     APMAG_PREFIX_KEY,
     APMAGUNC_PREFIX_KEY,
     ZP_KEY,
-    get_output_dir,
 )
 from mirar.processors.photometry.base_photometry import (
     AperturePhotometry,
@@ -96,7 +95,6 @@ class ImageAperturePhotometry(BaseImagePhotometry):
     def __init__(
         self,
         *args,
-        temp_output_sub_dir: str = "temp_aperture_photometry",
         aper_diameters: float | list[float] = 10.0,
         bkg_in_diameters: float | list[float] = 25.0,
         bkg_out_diameters: float | list[float] = 40.0,
@@ -116,10 +114,6 @@ class ImageAperturePhotometry(BaseImagePhotometry):
             self.col_suffix_list = self.aperture_photometer.aper_diameters
 
         self.zp_colname = zp_colname
-        self.temp_output_sub_dir = temp_output_sub_dir
-        self.photometry_out_temp_dir = get_output_dir(
-            self.temp_output_sub_dir, self.night_sub_dir
-        )
 
     def _apply_to_images(
         self,

--- a/mirar/processors/photometry/aperture_photometry.py
+++ b/mirar/processors/photometry/aperture_photometry.py
@@ -128,6 +128,17 @@ class ImageAperturePhotometry(BaseImagePhotometry):
         for image in batch:
             image_cutout, unc_image_cutout = self.generate_cutouts(image)
 
+            imagename, unc_imagename = self.get_image_filenames(image)
+            cutout_dir = "/Users/benjaminroulston/Documents/DATA_NOT_FOR_DROPBOX/SEDMv2/OUTPUT_DATA/image_cutouts/"
+            np.savetxt(
+                f"{cutout_dir}{imagename.name.replace('.fits', '_cutout.txt')}",
+                image_cutout,
+            )
+            np.savetxt(
+                f"{cutout_dir}{unc_imagename.name.replace('.fits.unc', '_unc_cutout.txt')}",
+                unc_image_cutout,
+            )
+
             fluxes, fluxuncs = self.aperture_photometer.perform_photometry(
                 image_cutout, unc_image_cutout
             )

--- a/mirar/processors/photometry/aperture_photometry.py
+++ b/mirar/processors/photometry/aperture_photometry.py
@@ -12,6 +12,7 @@ from mirar.paths import (
     APMAG_PREFIX_KEY,
     APMAGUNC_PREFIX_KEY,
     ZP_KEY,
+    get_output_dir,
 )
 from mirar.processors.photometry.base_photometry import (
     AperturePhotometry,
@@ -95,6 +96,7 @@ class ImageAperturePhotometry(BaseImagePhotometry):
     def __init__(
         self,
         *args,
+        temp_output_sub_dir: str = "temp_aperture_photometry",
         aper_diameters: float | list[float] = 10.0,
         bkg_in_diameters: float | list[float] = 25.0,
         bkg_out_diameters: float | list[float] = 40.0,
@@ -114,6 +116,10 @@ class ImageAperturePhotometry(BaseImagePhotometry):
             self.col_suffix_list = self.aperture_photometer.aper_diameters
 
         self.zp_colname = zp_colname
+        self.temp_output_sub_dir = temp_output_sub_dir
+        self.photometry_out_temp_dir = get_output_dir(
+            self.temp_output_sub_dir, self.night_sub_dir
+        )
 
     def _apply_to_images(
         self,

--- a/mirar/processors/photometry/aperture_photometry.py
+++ b/mirar/processors/photometry/aperture_photometry.py
@@ -20,6 +20,8 @@ from mirar.processors.photometry.base_photometry import (
     BaseImagePhotometry,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class CandidateAperturePhotometry(BaseCandidatePhotometry):
     """
@@ -135,7 +137,8 @@ class ImageAperturePhotometry(BaseImagePhotometry):
                 image_cutout,
             )
             np.savetxt(
-                f"{cutout_dir}{unc_imagename.name.replace('.fits.unc', '_unc_cutout.txt')}",
+                f"{cutout_dir}{unc_imagename.name.replace('.fits.unc',\
+                                                          '_unc_cutout.txt')}",
                 unc_image_cutout,
             )
 
@@ -144,13 +147,16 @@ class ImageAperturePhotometry(BaseImagePhotometry):
             )
 
             for ind, flux in enumerate(fluxes):
-                fluxunc = fluxuncs[ind]
-                suffix = self.col_suffix_list[ind]
-                image[f"fluxap{suffix}"] = flux
-                image[f"fluxunc{suffix}"] = fluxunc
-                image[f"magap{suffix}"] = float(
-                    image[self.zp_colname]
-                ) - 2.5 * np.log10(flux)
-                image[f"magerrap{suffix}"] = 1.086 * fluxunc / flux
+                try:
+                    fluxunc = fluxuncs[ind]
+                    suffix = self.col_suffix_list[ind]
+                    image[f"fluxap{suffix}"] = flux
+                    image[f"fluxunc{suffix}"] = fluxunc
+                    image[f"magap{suffix}"] = float(
+                        image[self.zp_colname]
+                    ) - 2.5 * np.log10(flux)
+                    image[f"magerrap{suffix}"] = 1.086 * fluxunc / flux
+                except ValueError:
+                    logger.error(f"Aperture photometry failed on: {imagename=}")
 
         return batch


### PR DESCRIPTION
This PR adds aperture photometry to the SEDMv2 pipeline. We are currently using a default (i.e. not seeing/psf optimized) aperture radius.

This PR also: 
- tightens the SEDMv2 anet scale bounds to 5' - 7' (was 1' - 10').
- reduce anet timeout from 900s to 60s. (This may need discussion @saarahha )
- makes sure the `GAIN` fits keyword is added to all images in a MEF file

This should close #537 