### PR TITLE
Better Anet checking for success

### DIFF
--- a/mirar/pipelines/winter/load_winter_image.py
+++ b/mirar/pipelines/winter/load_winter_image.py
@@ -46,6 +46,7 @@ def clean_header(header: fits.Header) -> fits.Header:
     """
     header[GAIN_KEY] = 1.0
     header[SATURATE_KEY] = 40000.0
+
     header["UTCTIME"] = Time(header["UTCISO"], format="iso").isot
 
     date_t = Time(header["UTCTIME"])
@@ -215,12 +216,13 @@ def load_winter_mef_image(
     path: str | Path,
 ) -> list[Image]:
     """
-    Function to load iwinter mef images
+    Function to load winter mef images
 
     :param path: Path to image
     :return: list of images
     """
-    return open_mef_image(path, load_raw_winter_mef, extension_key="BOARD_ID")
+    images = open_mef_image(path, load_raw_winter_mef, extension_key="BOARD_ID")
+    return images
 
 
 def annotate_winter_subdet_headers(image: Image) -> Image:


### PR DESCRIPTION
Fix #549  and fix #545 . Check for .solved file rather than .fits, as definition of success. More images should fail by raising AstrometryNetError now, if they are failed to solve but generated a sextractor catalogue, rather than passing the anet processor and then raising mysterious FileNotFound errors later.