### PR TITLE
Dedicated Execution Timeout error

### DIFF
--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -266,7 +266,7 @@ astrometry = [
         search_radius_deg=1.0,
         sextractor_config_path=sextractor_anet_config["config_path"],
         use_weight=True,
-        timeout=60,
+        timeout=120,
     ),
     ImageSaver(output_dir_name="post_anet"),
     ImageDebatcher(),

--- a/mirar/processors/astrometry/anet/anet_processor.py
+++ b/mirar/processors/astrometry/anet/anet_processor.py
@@ -25,18 +25,14 @@ from mirar.processors.astromatic.sextractor.settings import (
     write_param_file,
     write_sextractor_config_to_file,
 )
-from mirar.processors.astrometry.anet.anet import run_astrometry_net_single
+from mirar.processors.astrometry.anet.anet import (
+    ASTROMETRY_TIMEOUT,
+    AstrometryNetError,
+    run_astrometry_net_single,
+)
 from mirar.processors.base_processor import BaseImageProcessor
 
 logger = logging.getLogger(__name__)
-
-ASTROMETRY_TIMEOUT = 900  # astrometry cmd execute timeout, in seconds
-
-
-class AstrometryNetError(ProcessorError):
-    """
-    Class for errors in astrometry.net
-    """
 
 
 class AstrometryNet(BaseImageProcessor):

--- a/mirar/utils/__init__.py
+++ b/mirar/utils/__init__.py
@@ -1,4 +1,10 @@
 """
 Module for util/helper functions
 """
-from mirar.utils.execute_cmd import ExecutionError, TimeoutExecutionError, execute, run_docker, run_local
+from mirar.utils.execute_cmd import (
+    ExecutionError,
+    TimeoutExecutionError,
+    execute,
+    run_docker,
+    run_local,
+)

--- a/mirar/utils/__init__.py
+++ b/mirar/utils/__init__.py
@@ -1,4 +1,4 @@
 """
 Module for util/helper functions
 """
-from mirar.utils.execute_cmd import ExecutionError, execute, run_docker, run_local
+from mirar.utils.execute_cmd import ExecutionError, TimeoutExecutionError, execute, run_docker, run_local


### PR DESCRIPTION
Many winter images are failing due to Anet timeout. This PR addresses by:

- Bumping Anet timeout for WINTER
- introducing a dedicated execution timeout error
- and catching this in anet.

It also cleans up some pre-existing duplication in Anet.