### PR TITLE
sedmv2 realtime

### DIFF
--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -221,3 +221,17 @@ subtract = [
 ]
 
 imsub = subtract  # + export_diff_to_db + extract_candidates
+
+
+detrend_only = [
+    MaskPixelsFromPath(mask_path=sedmv2_mask_path),
+    BiasCalibrator(),
+    ImageSelector((OBSCLASS_KEY, ["flat", "science"])),
+    ImageBatcher(
+        split_key="filterid"
+    ),  # maybe change back to filter after revising load func
+    FlatCalibrator(),
+    ImageBatcher(split_key=BASE_NAME_KEY),
+    ImageSelector((OBSCLASS_KEY, ["science"])),  # pylint: disable=duplicate-code
+    ImageSaver(output_dir_name="detrend", write_mask=True),
+]

--- a/mirar/pipelines/sedmv2/sedmv2_pipeline.py
+++ b/mirar/pipelines/sedmv2/sedmv2_pipeline.py
@@ -10,6 +10,7 @@ from mirar.downloader.caltech import download_via_ssh
 from mirar.io import open_mef_image
 from mirar.pipelines.base_pipeline import Pipeline
 from mirar.pipelines.sedmv2.blocks import (
+    detrend_only,
     image_photometry,
     load_raw,
     process_stellar,
@@ -36,6 +37,7 @@ class SEDMv2Pipeline(Pipeline):
         "default": load_raw + process_stellar,
         "default_stellar": load_raw + process_stellar + image_photometry,
         "default_transient": load_raw + process_transient,  # +imsub,
+        "realtime": load_raw + detrend_only,  # +much more...
     }
 
     @staticmethod


### PR DESCRIPTION
This PR is the first step towards using the `Monitor` class for sedmv2. It adds a "realtime" configuration that will do simple detrend reductions (starting small as the bash script/cronjob/email-sender setup is still in progress).