### PR TITLE
Add InvalidImage

### DIFF
--- a/mirar/pipelines/sedmv2/blocks.py
+++ b/mirar/pipelines/sedmv2/blocks.py
@@ -49,7 +49,7 @@ from mirar.processors.zogy.zogy import ZOGY, ZOGYPrepare
 
 load_raw = [
     MEFLoader(
-        input_sub_dir="raw",
+        input_sub_dir="",
         load_image=load_sedmv2_mef_image,
     ),
     ImageSaver(output_dir_name="loaded"),

--- a/mirar/pipelines/sedmv2/load_sedmv2_image.py
+++ b/mirar/pipelines/sedmv2/load_sedmv2_image.py
@@ -20,6 +20,7 @@ from mirar.paths import (
     TARGET_KEY,
     __version__,
 )
+from mirar.processors.utils.image_loader import InvalidImage
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,17 @@ def load_raw_sedmv2_mef(
     """
     Load mef image
     """
+
+    sedmv2_ignore_files = [
+        "dark",
+        "sedm2",
+        "speccal",
+    ]
+
+    if any(ext in Path(path).name for ext in sedmv2_ignore_files):
+        logger.debug(f"Skipping unneeded SEDMv2 file {path}.")
+        raise InvalidImage
+
     header, split_data, split_headers = open_mef_fits(path)
 
     if "IMGTYPE" in header.keys():  # mode fritz

--- a/mirar/processors/utils/image_loader.py
+++ b/mirar/processors/utils/image_loader.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from tqdm import tqdm
 
 from mirar.data import Image, ImageBatch
-from mirar.errors import ImageNotFoundError, ProcessorError
+from mirar.errors import ImageNotFoundError, NoncriticalProcessingError, ProcessorError
 from mirar.io import (
     MissingCoreFieldError,
     check_file_is_complete,
@@ -28,7 +28,7 @@ class BadImageError(ProcessorError):
     """Exception for bad images"""
 
 
-class InvalidImage(ProcessorError):
+class InvalidImage(NoncriticalProcessingError):
     """Image should be skipped"""
 
 

--- a/mirar/processors/utils/image_loader.py
+++ b/mirar/processors/utils/image_loader.py
@@ -28,6 +28,10 @@ class BadImageError(ProcessorError):
     """Exception for bad images"""
 
 
+class InvalidImage(ProcessorError):
+    """Image should be skipped"""
+
+
 def unzip(zipped_list: list[str]) -> list[str]:
     """
     Function to unzip a list of files?
@@ -71,17 +75,20 @@ def load_from_dir(
 
     for path in tqdm(img_list):
         if check_file_is_complete(path):
-            image_list = open_f(path)
+            try:
+                image_list = open_f(path)
 
-            if not isinstance(image_list, list):
-                image_list = [image_list]
+                if not isinstance(image_list, list):
+                    image_list = [image_list]
 
-            for image in image_list:
-                try:
-                    check_image_has_core_fields(image)
-                except MissingCoreFieldError as err:
-                    raise BadImageError(err) from err
-                images.append(image)
+                for image in image_list:
+                    try:
+                        check_image_has_core_fields(image)
+                    except MissingCoreFieldError as err:
+                        raise BadImageError(err) from err
+                    images.append(image)
+            except InvalidImage:
+                logger.debug(f"Image {path} is invalid. Skipping!")
         else:
             logger.warning(f"File {path} is not complete. Skipping!")
 


### PR DESCRIPTION
Add dedicated non-critical ImageLoader error for images that should not be loaded, e.g SEDmv2 spectra.

Fixed #588 (indirectly)