### PR TITLE
Add undeprecated check for WFCAM

### DIFF
--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -373,9 +373,9 @@ load_test_stack = [
 load_stack = [
     ImageLoader(input_sub_dir="final", input_img_dir=base_output_dir),
     ImageBatcher(["BOARD_ID", "FILTER", TARGET_KEY, "SUBCOORD"]),
-    ImageSelector(
-        (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_4_0_1_stack.fits")
-    ),
+    # ImageSelector(
+    #     (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_4_0_1_stack.fits")
+    # ),
 ]
 
 imsub = [

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -13,6 +13,7 @@ from mirar.paths import (
     OBSCLASS_KEY,
     TARGET_KEY,
     ZP_KEY,
+    ZP_STD_KEY,
     base_output_dir,
 )
 from mirar.pipelines.winter.config import (
@@ -376,6 +377,8 @@ load_stack = [
     ImageSelector(
         (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_2_0_0.fits_stack.fits")
     ),
+    HeaderAnnotator(input_keys=["ZP_AUTO"], output_key=ZP_KEY),
+    HeaderAnnotator(input_keys=["ZP_AUTO_STD"], output_key=ZP_STD_KEY),
 ]
 
 imsub = [

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -374,7 +374,7 @@ load_stack = [
     ImageLoader(input_sub_dir="final", input_img_dir=base_output_dir),
     ImageBatcher(["BOARD_ID", "FILTER", TARGET_KEY, "SUBCOORD"]),
     ImageSelector(
-        (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_2_0_0_stack.fits")
+        (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_4_0_1_stack.fits")
     ),
 ]
 

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -371,7 +371,7 @@ load_test_stack = [
 ]
 
 load_stack = [
-    ImageLoader(input_sub_dir="final"),
+    ImageLoader(input_sub_dir="final", input_img_dir=base_output_dir),
     ImageBatcher(["BOARD_ID", "FILTER", TARGET_KEY, "SUBCOORD"]),
     ImageSelector(
         (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_2_0_0.fits_stack.fits")

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -13,7 +13,6 @@ from mirar.paths import (
     OBSCLASS_KEY,
     TARGET_KEY,
     ZP_KEY,
-    ZP_STD_KEY,
     base_output_dir,
 )
 from mirar.pipelines.winter.config import (
@@ -375,10 +374,8 @@ load_stack = [
     ImageLoader(input_sub_dir="final", input_img_dir=base_output_dir),
     ImageBatcher(["BOARD_ID", "FILTER", TARGET_KEY, "SUBCOORD"]),
     ImageSelector(
-        (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_2_0_0.fits_stack.fits")
+        (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_2_0_0_stack.fits")
     ),
-    HeaderAnnotator(input_keys=["ZP_AUTO"], output_key=ZP_KEY),
-    HeaderAnnotator(input_keys=["ZP_AUTO_STD"], output_key=ZP_STD_KEY),
 ]
 
 imsub = [

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -373,9 +373,9 @@ load_test_stack = [
 load_stack = [
     ImageLoader(input_sub_dir="final"),
     ImageBatcher(["BOARD_ID", "FILTER", TARGET_KEY, "SUBCOORD"]),
-    # ImageSelector(
-    #     (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_4_0_1.fits_stack.fits")
-    # ),
+    ImageSelector(
+        (BASE_NAME_KEY, "WINTERcamera_20230727-035357-778_mef_2_0_0.fits_stack.fits")
+    ),
 ]
 
 imsub = [

--- a/mirar/pipelines/winter/models/_candidates.py
+++ b/mirar/pipelines/winter/models/_candidates.py
@@ -264,11 +264,11 @@ class Candidate(BaseDB):
     elong: float = Field(ge=0)
     nneg: int | None = Field(ge=0, default=None)
     nbad: int | None = Field(ge=0, default=None)
-    sumrat: float | None = Field(ge=0, default=None)
+    sumrat: float | None = Field(default=None)
 
-    dsnrms: float | None = Field(ge=0, default=None)
-    ssnrms: float | None = Field(ge=0, default=None)
-    dsdiff: float | None = Field(ge=0, default=None)
+    dsnrms: float | None = Field(default=None)
+    ssnrms: float | None = Field(default=None)
+    dsdiff: float | None = Field(default=None)
 
     scorr: float = Field(ge=0)
 

--- a/mirar/pipelines/winter/models/_ref_stacks.py
+++ b/mirar/pipelines/winter/models/_ref_stacks.py
@@ -56,7 +56,7 @@ class RefStack(BaseDB):
     ra1_1: float = ra_field
     dec1_1: float = dec_field
     filter: str = Field(min_length=1)
-    coadds: int = Field(ge=0)
+    coadds: int = Field(ge=1)
     zp: float = Field(ge=0)
     zpstd: float = Field(ge=0)
 

--- a/mirar/pipelines/winter/models/_ref_stacks.py
+++ b/mirar/pipelines/winter/models/_ref_stacks.py
@@ -32,6 +32,7 @@ class RefStacksTable(WinterBase):
     subdetid = Column(Integer, nullable=True, default=None)
     filter = Column(VARCHAR(10))
     savepath = Column(VARCHAR(255), unique=True)
+    coadds = Column(Integer)
     zp = Column(Float)
     zpstd = Column(Float)
 
@@ -55,6 +56,7 @@ class RefStack(BaseDB):
     ra1_1: float = ra_field
     dec1_1: float = dec_field
     filter: str = Field(min_length=1)
+    coadds: int = Field(ge=0)
     zp: float = Field(ge=0)
     zpstd: float = Field(ge=0)
 

--- a/mirar/references/wfcam/files/__init__.py
+++ b/mirar/references/wfcam/files/__init__.py
@@ -1,0 +1,9 @@
+"""
+This module contains references to files used by the wfcam module.
+"""
+
+from pathlib import Path
+
+wfcam_undeprecated_compid_file = (
+    Path(__file__).parent / "wfcam_undeprecated_compids.csv"
+)

--- a/mirar/references/wfcam/wfcam_stack.py
+++ b/mirar/references/wfcam/wfcam_stack.py
@@ -37,7 +37,7 @@ def default_filter_wfau_images(image_batch: ImageBatch) -> ImageBatch:
     Function to filter WFAU images based on zeropoints and seeing.
     The images are filtered to remove images with wildly different zeropoints (more than
     0.4 mag from the median zeropoint)
-    and seeing < 0 or > 2.5 arcsec.
+    and seeing <= 0 or > 3.5 arcsec.
     Args:
         :param image_batch: ImageBatch
 
@@ -58,7 +58,7 @@ def default_filter_wfau_images(image_batch: ImageBatch) -> ImageBatch:
     median_mag_zp = np.median(mag_zps)
     seeings = np.array([x["SEEING"] for x in image_batch])
     zpmask = np.abs(mag_zps - median_mag_zp) < 0.4
-    seeingmask = (seeings < 2.5) & (seeings > 0)
+    seeingmask = (seeings < 3.5 / 0.4) & (seeings > 0)
 
     image_array = image_array[zpmask & seeingmask]
 

--- a/tests/test_winter_imsub_pipeline.py
+++ b/tests/test_winter_imsub_pipeline.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 NIGHT_NAME = "20230726"
 
 EXPECTED_HEADER_VALUES = {
-    "SCORMEAN": -0.12368322492306351,
-    "SCORMED": -0.12509273600806523,
-    "SCORSTD": 1.2881531096254784,
+    "SCORMEAN": -0.13625905938349483,
+    "SCORMED": -0.13512726465303718,
+    "SCORSTD": 1.3021071256299737,
 }
 EXPECTED_DATAFRAME_VALUES = {
-    "magpsf": [14.93305887365752, 12.52662796885793],
-    "magap": [14.85368864982879, 12.073671653301519],
+    "magpsf": [12.173105476828795],
+    "magap": [12.062389584233465],
 }
 
 
@@ -92,7 +92,7 @@ class TestWinterImsubPipeline(BaseTestCase):
                     f"Type for value ({type(value)} is neither float not int."
                 )
 
-        self.assertEqual(len(candidates_table), 2)
+        self.assertEqual(len(candidates_table), 1)
         for key, value in EXPECTED_DATAFRAME_VALUES.items():
             if isinstance(value, list):
                 for ind, val in enumerate(value):


### PR DESCRIPTION
This PR makes sure only undeprecated files from WFAU, ensuring only good images are used. This also makes any functionality involving downloading these much quicker, and ensures consistency with use-cases where images are stored locally (like winter server).
Also relaxes the threshold for seeing and adds coadds column to refstacks table.