### PR TITLE
Better deduplication

### DIFF
--- a/mirar/database/base_model.py
+++ b/mirar/database/base_model.py
@@ -132,18 +132,25 @@ class BaseDB(PydanticBase):
 
             assert len(present_unique_keys) > 0
 
-            constraints = DBQueryConstraints(
-                columns=[x.name for x in present_unique_keys],
-                accepted_values=[
-                    self.model_dump()[x.name] for x in present_unique_keys
-                ],
-            )
+            res = None
 
-            res = select_from_table(
-                sql_table=self.sql_model,
-                db_constraints=constraints,
-                output_columns=returning_key_names,
-            )
+            for key in present_unique_keys:
+                constraint = DBQueryConstraints(
+                    columns=[key.name],
+                    accepted_values=[self.model_dump()[key.name]],
+                )
+                new_res = select_from_table(
+                    sql_table=self.sql_model,
+                    db_constraints=constraint,
+                    output_columns=returning_key_names,
+                )
+
+                if res is None:
+                    res = new_res
+                elif new_res != res:
+                    raise ValueError(
+                        f"Multiple matches found: {new_res} and {res}"
+                    ) from exc
 
         return res
 

--- a/mirar/database/base_model.py
+++ b/mirar/database/base_model.py
@@ -145,12 +145,16 @@ class BaseDB(PydanticBase):
                     output_columns=returning_key_names,
                 )
 
-                if res is None:
-                    res = new_res
-                elif not new_res.equals(res):
-                    raise ValueError(
-                        f"Multiple matches found: {new_res} and {res}"
-                    ) from exc
+                if len(new_res) > 1:
+                    if res is None:
+                        res = new_res
+                    elif not new_res.equals(res):
+                        raise ValueError(
+                            f"Multiple matches found: {new_res} and {res}"
+                        ) from exc
+
+            if res is None:
+                raise ValueError("No results found") from exc
 
         return res
 

--- a/mirar/database/base_model.py
+++ b/mirar/database/base_model.py
@@ -147,7 +147,7 @@ class BaseDB(PydanticBase):
 
                 if res is None:
                     res = new_res
-                elif new_res != res:
+                elif not new_res.equals(res):
                     raise ValueError(
                         f"Multiple matches found: {new_res} and {res}"
                     ) from exc

--- a/mirar/database/base_model.py
+++ b/mirar/database/base_model.py
@@ -145,7 +145,7 @@ class BaseDB(PydanticBase):
                     output_columns=returning_key_names,
                 )
 
-                if len(new_res) > 1:
+                if len(new_res) > 0:
                     if res is None:
                         res = new_res
                     elif not new_res.equals(res):


### PR DESCRIPTION
Using old cals means images can go through the pipeline on multiple nights. You will get an integrity error, where rawid exists but savepath does not. This PR adds a check to see if the existing entry can be found.