### PR TITLE
SEDMv2 mode0 loading

### DIFF
--- a/mirar/pipelines/sedmv2/load_sedmv2_image.py
+++ b/mirar/pipelines/sedmv2/load_sedmv2_image.py
@@ -25,7 +25,7 @@ from mirar.processors.utils.image_loader import InvalidImage
 logger = logging.getLogger(__name__)
 
 
-def clean_science_header(
+def clean_science_header(  # pylint: disable=too-many-branches
     header: fits.Header, split_headers: list[fits.Header], is_mode0: bool
 ) -> tuple[fits.Header, list[fits.Header]]:
     """
@@ -65,7 +65,10 @@ def clean_science_header(
 
     # filters
     header["FILTERID"] = informative_hdr["FILTER"].split(" ")[1][0]
-    header["FILTER"] = informative_hdr["FILTERID"]
+    header["FILTER"] = header["FILTERID"]
+    if is_mode0:
+        informative_hdr["FILTER"] = header["FILTER"]
+        informative_hdr["FILTERID"] = header["FILTERID"]
 
     # keys, IDs ("core fields")
     header[PROC_HISTORY_KEY] = ""
@@ -104,9 +107,10 @@ def clean_cal_header(
     if hdr0["IMGTYPE"] == "flat":
         filt = filepath.split("flat_s")[1][0]  # sedm-specific file name structure
         hdr0["FILTERID"] = filt
-        hdr0["FILTER"] = f"SDSS {filt}' (Chroma)"
+        hdr0["FILTER"] = filt  # f"SDSS {filt}'"  #f"SDSS {filt}' (Chroma)"
     if hdr0["IMGTYPE"] == "bias":
-        hdr0["FILTER"] = "SDSS g"  # arbitrary filter for bias
+        hdr0["FILTER"] = "g"  # arbitrary filter for bias
+        hdr0["FILTERID"] = "g"  # arbitrary filter for bias
 
     hdr0["SOURCE"] = "None"
     hdr0["COADDS"] = 1

--- a/mirar/pipelines/sedmv2/load_sedmv2_image.py
+++ b/mirar/pipelines/sedmv2/load_sedmv2_image.py
@@ -31,12 +31,12 @@ def clean_science_header(
     """
     function to modify the primary header of an SEDMv2 science file
     :param header: original primary header of science file
-    :param split_headers: the remaining headers,one for each extension of MEF
+    :param split_headers: the remaining headers, one for each extension of MEF
     :param is_mode0: True if observed in SEDMv2 observation mode 0
-    :return: modified header
+    :return: modified primary header
     """
     if is_mode0:
-        # bulk of information is not stored in primary header for mode0
+        # main information is not stored in primary header for mode0
         informative_hdr = split_headers[0]
     else:
         informative_hdr = header
@@ -50,12 +50,12 @@ def clean_science_header(
     header["TELRA"] = informative_hdr["TELRAD"]
     header["TELDEC"] = informative_hdr["TELDECD"]
 
+    # gain
     if GAIN_KEY in informative_hdr:
         if header[GAIN_KEY] == 0.0:
             header[GAIN_KEY] = 1.0
     else:
         header[GAIN_KEY] = 1.0
-
     for ext in split_headers:
         if GAIN_KEY in ext:
             if ext[GAIN_KEY] == 0.0:


### PR DESCRIPTION
This small PR makes it possible to load in SEDMv2 mode0 science images again. It does this by adding the argument `is_mode0` to the loading function (`load_sedmv2_image.clean_science_header`). This is necessary since, for observations made in mode0, key information is stored in the secondary header instead of the primary.