### PR TITLE
Add source table

### DIFF
--- a/mirar/database/base_model.py
+++ b/mirar/database/base_model.py
@@ -74,8 +74,8 @@ class BaseDB(PydanticBase):
 
     def _insert_entry(
         self,
+        duplicate_protocol: str,
         returning_key_names: str | list[str] = None,
-        duplicate_protocol: str = "ignore",
     ) -> pd.DataFrame:
         """
         Insert the pydantic-ified data into the corresponding sql database
@@ -186,15 +186,21 @@ class BaseDB(PydanticBase):
         return [x for x in self.get_unique_keys() if x.name in self.model_fields]
 
     def insert_entry(
-        self, returning_key_names: str | list[str] | None = None
+        self,
+        duplicate_protocol: str,
+        returning_key_names: str | list[str] | None = None,
     ) -> pd.DataFrame:
         """
         Insert the pydantic-ified data into the corresponding sql database
 
+        :param duplicate_protocol: protocol to follow if duplicate entry is found
         :param returning_key_names: names of the keys to return
         :return: dataframe of the sequence keys
         """
-        result = self._insert_entry(returning_key_names=returning_key_names)
+        result = self._insert_entry(
+            duplicate_protocol=duplicate_protocol,
+            returning_key_names=returning_key_names,
+        )
         logger.debug(f"Return result {result}")
         return result
 
@@ -217,6 +223,9 @@ class BaseDB(PydanticBase):
         )
 
         full_dict = self.model_dump()
+
+        if update_key_names is None:
+            update_key_names = full_dict.keys()
 
         update_dict = {key: full_dict[key] for key in update_key_names}
 

--- a/mirar/pipelines/summer/models/_exposures.py
+++ b/mirar/pipelines/summer/models/_exposures.py
@@ -163,21 +163,28 @@ class Exposure(BaseDB):
         """
         return datetime.strptime(nightdate, SUMMER_NIGHT_FORMAT)
 
-    def insert_entry(self, returning_key_names=None) -> pd.DataFrame:
+    def insert_entry(
+        self, duplicate_protocol: str, returning_key_names=None
+    ) -> pd.DataFrame:
         """
         Insert the pydantic-ified data into the corresponding sql database
 
-        :return: None
+        :param duplicate_protocol: protocol to follow if duplicate entry is found
+        :param returning_key_names: names of keys to return
+        :return: DataFrame of returning keys
         """
         night = Night(nightdate=self.nightdate)
         if not night.exists():
-            night.insert_entry()
+            night.insert_entry(duplicate_protocol="ignore")
 
         logger.debug(f"puid: {self.puid}")
         if not Program._exists(values=self.puid, keys="puid"):
             self.puid = 1
 
-        return self._insert_entry()
+        return self._insert_entry(
+            duplicate_protocol=duplicate_protocol,
+            returning_key_names=returning_key_names,
+        )
 
     def exists(self) -> bool:
         """

--- a/mirar/pipelines/summer/models/_filters.py
+++ b/mirar/pipelines/summer/models/_filters.py
@@ -71,4 +71,4 @@ def populate_filters(filter_map: dict = None):
     for filter_name, fid in filter_map.items():
         summer_filter = Filter(fid=fid, filtername=filter_name)
         if not summer_filter.exists():
-            summer_filter.insert_entry()
+            summer_filter.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/summer/models/_img_type.py
+++ b/mirar/pipelines/summer/models/_img_type.py
@@ -57,4 +57,4 @@ def populate_itid():
     for i, img_type in enumerate(ALL_ITID):
         itid = ImgType(itid=i + 1, imgtype=img_type)
         if not itid.exists():
-            itid.insert_entry()
+            itid.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/summer/models/_programs.py
+++ b/mirar/pipelines/summer/models/_programs.py
@@ -132,4 +132,4 @@ def populate_programs():
     """
 
     if not default_program.exists():
-        default_program.insert_entry()
+        default_program.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/summer/models/_subdets.py
+++ b/mirar/pipelines/summer/models/_subdets.py
@@ -68,4 +68,4 @@ def populate_subdets(ndetectors: int = 1, nxtot: int = 1, nytot: int = 1):
                         nxtot=nxtot,
                         nytot=nytot,
                     )
-                    new.insert_entry()
+                    new.insert_entry(duplicate_protocol="fail")

--- a/mirar/pipelines/winter/models/__init__.py
+++ b/mirar/pipelines/winter/models/__init__.py
@@ -12,12 +12,7 @@ from mirar.pipelines.winter.models._astrometry_stats import (
     AstrometryStat,
     AstrometryStatsTable,
 )
-from mirar.pipelines.winter.models._candidates import (
-    CANDIDATE_PREFIX,
-    NAME_START,
-    Candidate,
-    CandidatesTable,
-)
+from mirar.pipelines.winter.models._candidates import Candidate, CandidatesTable
 from mirar.pipelines.winter.models._diff import Diff, DiffsTable
 from mirar.pipelines.winter.models._exposures import Exposure, ExposuresTable
 from mirar.pipelines.winter.models._fields import (
@@ -55,6 +50,13 @@ from mirar.pipelines.winter.models._ref_components import (
 )
 from mirar.pipelines.winter.models._ref_queries import RefQueriesTable, RefQuery
 from mirar.pipelines.winter.models._ref_stacks import RefStack, RefStacksTable
+from mirar.pipelines.winter.models._sources import (
+    MIN_NAME_LENGTH,
+    NAME_START,
+    SOURCE_PREFIX,
+    Source,
+    SourcesTable,
+)
 from mirar.pipelines.winter.models._stack import Stack, StacksTable
 from mirar.pipelines.winter.models._subdets import (
     Subdet,
@@ -85,7 +87,14 @@ def set_up_q3c(db_name: str, db_table: BaseTable):
 if DB_USER is not None:
     setup_database(db_base=WinterBase)
 
-    for table in [ExposuresTable, CandidatesTable, RefQueriesTable, StacksTable]:
+    for table in [
+        ExposuresTable,
+        AstrometryStatsTable,
+        CandidatesTable,
+        RefQueriesTable,
+        StacksTable,
+        SourcesTable,
+    ]:
         set_up_q3c(db_name=WinterBase.db_name, db_table=table)
 
     populate_fields()

--- a/mirar/pipelines/winter/models/_candidates.py
+++ b/mirar/pipelines/winter/models/_candidates.py
@@ -59,10 +59,13 @@ class CandidatesTable(WinterBase):  # pylint: disable=too-few-public-methods
 
     # Image properties
 
-    diffid: Mapped[int] = mapped_column(ForeignKey("diffs.diffid"))  # FIXME
+    sourceid: Mapped[int] = mapped_column(ForeignKey("sources.sourceid"))
+    source: Mapped["SourcesTable"] = relationship(back_populates="candidates")
+
+    diffid: Mapped[int] = mapped_column(ForeignKey("diffs.diffid"))
     diff_id: Mapped["DiffsTable"] = relationship(back_populates="candidates")
 
-    stackid: Mapped[int] = mapped_column(ForeignKey("stacks.stackid"))  # FIXME
+    stackid: Mapped[int] = mapped_column(ForeignKey("stacks.stackid"))
     stack_id: Mapped["StacksTable"] = relationship(back_populates="candidates")
 
     fid: Mapped[int] = mapped_column(ForeignKey("filters.fid"))
@@ -211,6 +214,8 @@ class Candidate(BaseDB):
 
     objectid: str = Field(min_length=MIN_NAME_LENGTH)
     deprecated: bool = Field(default=False)
+
+    sourceid: int = Field(ge=0)
 
     jd: float = Field(ge=0)
 

--- a/mirar/pipelines/winter/models/_candidates.py
+++ b/mirar/pipelines/winter/models/_candidates.py
@@ -332,10 +332,14 @@ class Candidate(BaseDB):
     maggaia: float | None = Field(default=None)
     maggaiabright: float | None = Field(default=None)
 
-    def insert_entry(self, returning_key_names=None) -> pd.DataFrame:
+    def insert_entry(
+        self, duplicate_protocol, returning_key_names=None
+    ) -> pd.DataFrame:
         """
         Insert the pydantic-ified data into the corresponding sql database
 
+        :param duplicate_protocol: protocol to follow if duplicate entry is found
+        :param returning_key_names: names of the keys to return
         :return: None
         """
 
@@ -350,4 +354,7 @@ class Candidate(BaseDB):
             )
             self.progname = default_program.progname
 
-        return self._insert_entry(returning_key_names=returning_key_names)
+        return self._insert_entry(
+            duplicate_protocol=duplicate_protocol,
+            returning_key_names=returning_key_names,
+        )

--- a/mirar/pipelines/winter/models/_diff.py
+++ b/mirar/pipelines/winter/models/_diff.py
@@ -74,11 +74,15 @@ class Diff(BaseDB):
         return savepath
 
     def insert_entry(
-        self, returning_key_names: str | list[str] | None = None
+        self,
+        duplicate_protocol: str,
+        returning_key_names: str | list[str] | None = None,
     ) -> pd.DataFrame:
         """
         Insert entry into database
+
         :param returning_key_names: names of keys to return
+        :param duplicate_protocol: protocol to follow if duplicate entry is found
         :return: dataframe of inserted entries
         """
         dbconstraints = DBQueryConstraints()
@@ -92,4 +96,7 @@ class Diff(BaseDB):
             db_constraints=dbconstraints,
         )
 
-        return self._insert_entry(returning_key_names=returning_key_names)
+        return self._insert_entry(
+            duplicate_protocol=duplicate_protocol,
+            returning_key_names=returning_key_names,
+        )

--- a/mirar/pipelines/winter/models/_filters.py
+++ b/mirar/pipelines/winter/models/_filters.py
@@ -70,4 +70,4 @@ def populate_filters(filter_map: dict = None):
     for filter_name, fid in filter_map.items():
         winter_filter = Filter(fid=fid, filtername=filter_name)
         if not winter_filter.exists():
-            winter_filter.insert_entry()
+            winter_filter.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/winter/models/_img_type.py
+++ b/mirar/pipelines/winter/models/_img_type.py
@@ -59,4 +59,4 @@ def populate_itid():
     for ind, imgtype in enumerate(ALL_ITID):
         itid = ImgType(itid=ind + 1, imgtype=imgtype)
         if not itid.exists():
-            itid.insert_entry()
+            itid.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/winter/models/_programs.py
+++ b/mirar/pipelines/winter/models/_programs.py
@@ -134,4 +134,4 @@ def populate_programs():
     """
 
     if not default_program.exists():
-        default_program.insert_entry()
+        default_program.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/winter/models/_sources.py
+++ b/mirar/pipelines/winter/models/_sources.py
@@ -33,7 +33,7 @@ class SourcesTable(WinterBase):  # pylint: disable=too-few-public-methods
     # Core fields
     sourceid = Column(
         BigInteger,
-        Sequence(name="sources_candid_seq", start=0, increment=1),
+        Sequence(name="sources_candid_seq", start=1, increment=1),
         unique=True,
         autoincrement=True,
         primary_key=True,

--- a/mirar/pipelines/winter/models/_sources.py
+++ b/mirar/pipelines/winter/models/_sources.py
@@ -1,0 +1,69 @@
+"""
+Models for the 'sources' table
+"""
+
+import logging
+from typing import ClassVar, List
+
+from pydantic import Field
+from sqlalchemy import VARCHAR, BigInteger, Boolean, Column, Float, Integer, Sequence
+from sqlalchemy.orm import Mapped, relationship
+
+from mirar.database.base_model import BaseDB, dec_field, ra_field
+from mirar.pipelines.winter.models.base_model import WinterBase
+
+logger = logging.getLogger(__name__)
+
+SOURCE_PREFIX = "WNTR"
+NAME_START = "aaaaa"
+
+MIN_NAME_LENGTH = len(SOURCE_PREFIX) + len(NAME_START) + 2
+
+
+class SourcesTable(WinterBase):  # pylint: disable=too-few-public-methods
+    """
+    Sources table in database
+    """
+
+    __tablename__ = "sources"
+    __table_args__ = {"extend_existing": True}
+
+    # extra avro_path, diff img foreign key etc
+
+    # Core fields
+    sourceid = Column(
+        BigInteger,
+        Sequence(name="sources_candid_seq", start=0, increment=1),
+        unique=True,
+        autoincrement=True,
+        primary_key=True,
+    )
+    objectid = Column(VARCHAR(40), nullable=False, unique=True)
+    deprecated = Column(Boolean, nullable=False, default=False)
+
+    # Positional properties
+
+    average_ra = Column(Float)
+    average_dec = Column(Float)
+    ra_column_name = "average_ra"
+    dec_column_name = "average_dec"
+
+    ndet = Column(Integer, nullable=False, default=1)
+
+    candidates: Mapped[List["CandidatesTable"]] = relationship(back_populates="source")
+
+
+class Source(BaseDB):
+    """
+    A pydantic model for a source database entry
+    """
+
+    sql_model: ClassVar = SourcesTable
+
+    objectid: str = Field(min_length=MIN_NAME_LENGTH)
+    deprecated: bool = Field(default=False)
+
+    average_ra: float = ra_field
+    average_dec: float = dec_field
+
+    ndet: int = Field(ge=1, description="Number of detections", default=1)

--- a/mirar/pipelines/winter/models/_subdets.py
+++ b/mirar/pipelines/winter/models/_subdets.py
@@ -60,4 +60,4 @@ def populate_subdets():
                 ny=row["ny"],
                 nytot=row["nytot"],
             )
-            new.insert_entry()
+            new.insert_entry(duplicate_protocol="ignore")

--- a/mirar/pipelines/wirc/blocks.py
+++ b/mirar/pipelines/wirc/blocks.py
@@ -55,8 +55,8 @@ from mirar.processors.csvlog import CSVLog
 from mirar.processors.dark import DarkCalibrator
 from mirar.processors.database.database_inserter import DatabaseSourceInserter
 from mirar.processors.database.database_selector import (
-    CrossmatchSourceWithDatabase,
     DatabaseHistorySelector,
+    SpatialCrossmatchSourceWithDatabase,
 )
 from mirar.processors.flat import SkyFlatCalibrator
 from mirar.processors.mask import (
@@ -252,7 +252,7 @@ process_candidates = [
     XMatch(catalog=TMASS(num_sources=3, search_radius_arcmin=0.5)),
     XMatch(catalog=PS1(num_sources=3, search_radius_arcmin=0.5)),
     SourceWriter(output_dir_name="kowalski"),
-    CrossmatchSourceWithDatabase(
+    SpatialCrossmatchSourceWithDatabase(
         db_table=Candidate,
         db_output_columns=[SOURCE_NAME_KEY],
         crossmatch_radius_arcsec=2.0,

--- a/mirar/processors/base_processor.py
+++ b/mirar/processors/base_processor.py
@@ -555,4 +555,5 @@ class BaseSourceProcessor(BaseProcessor, ABC):
         super_dict.update(
             {key.lower(): val for key, val in source_row.to_dict().items()}
         )
+        super_dict.update({key.upper(): val for key, val in super_dict.items()})
         return super_dict

--- a/mirar/processors/database/__init__.py
+++ b/mirar/processors/database/__init__.py
@@ -8,7 +8,9 @@ from mirar.processors.database.database_inserter import (
 )
 from mirar.processors.database.database_selector import (
     BaseDatabaseSourceSelector,
-    CrossmatchSourceWithDatabase,
     DatabaseHistorySelector,
+    SelectSourcesWithMetadata,
+    SingleSpatialCrossmatchSource,
+    SpatialCrossmatchSourceWithDatabase,
 )
 from mirar.processors.database.database_updater import ImageDatabaseUpdater

--- a/mirar/processors/database/base_database_processor.py
+++ b/mirar/processors/database/base_database_processor.py
@@ -7,7 +7,6 @@ from abc import ABC
 from typing import Type
 
 from mirar.database.base_model import BaseDB
-from mirar.database.constants import POSTGRES_DUPLICATE_PROTOCOLS
 from mirar.database.user import PostgresAdmin, PostgresUser
 from mirar.processors.base_processor import BaseProcessor
 
@@ -24,16 +23,10 @@ class BaseDatabaseProcessor(BaseProcessor, ABC):
         db_table: Type[BaseDB],
         pg_user: PostgresUser = PostgresUser(),
         pg_admin: PostgresAdmin = PostgresAdmin(),
-        duplicate_protocol: str = "fail",
     ):
         super().__init__()
         self.db_table = db_table
         self.db_name = self.db_table.sql_model.db_name
-        self.duplicate_protocol = duplicate_protocol
 
         self.pg_user = pg_user
         self._pg_admin = pg_admin
-
-        assert (
-            self.duplicate_protocol in POSTGRES_DUPLICATE_PROTOCOLS
-        ), f"Invalid duplicate protocol, must be one of {POSTGRES_DUPLICATE_PROTOCOLS}"

--- a/mirar/processors/database/base_database_processor.py
+++ b/mirar/processors/database/base_database_processor.py
@@ -34,4 +34,6 @@ class BaseDatabaseProcessor(BaseProcessor, ABC):
         self.pg_user = pg_user
         self._pg_admin = pg_admin
 
-        assert self.duplicate_protocol in POSTGRES_DUPLICATE_PROTOCOLS
+        assert (
+            self.duplicate_protocol in POSTGRES_DUPLICATE_PROTOCOLS
+        ), f"Invalid duplicate protocol, must be one of {POSTGRES_DUPLICATE_PROTOCOLS}"

--- a/mirar/processors/database/database_selector.py
+++ b/mirar/processors/database/database_selector.py
@@ -12,7 +12,7 @@ import pandas as pd
 from mirar.data import DataBlock, Image, ImageBatch, SourceBatch
 from mirar.database.constraints import DBQueryConstraints
 from mirar.database.transactions import select_from_table
-from mirar.paths import SOURCE_HISTORY_KEY, SOURCE_XMATCH_KEY
+from mirar.paths import SOURCE_HISTORY_KEY
 from mirar.processors.base_processor import BaseImageProcessor, BaseSourceProcessor
 from mirar.processors.database.base_database_processor import BaseDatabaseProcessor
 
@@ -101,7 +101,7 @@ class BaseImageDatabaseSelector(BaseDatabaseSelector, BaseImageProcessor, ABC):
         return batch
 
 
-class CrossmatchDatabaseWithHeader(BaseImageDatabaseSelector):
+class BaseValuesCrossmatch(BaseDatabaseSelector, ABC):
     """Processor to crossmatch to a database"""
 
     def __init__(self, db_query_columns: str | list[str], *args, **kwargs):
@@ -134,6 +134,12 @@ class CrossmatchDatabaseWithHeader(BaseImageDatabaseSelector):
             comparison_types=comparison_types,
         )
         return query_constraints
+
+
+class CrossmatchDatabaseWithHeader(BaseImageDatabaseSelector, BaseValuesCrossmatch):
+    """
+    Processor to crossmatch to a database using keys
+    """
 
 
 class BaseDatabaseSourceSelector(BaseDatabaseSelector, BaseSourceProcessor, ABC):
@@ -199,9 +205,73 @@ class BaseDatabaseSourceSelector(BaseDatabaseSelector, BaseSourceProcessor, ABC)
         return batch
 
 
-class CrossmatchSourceWithDatabase(BaseDatabaseSourceSelector, BaseSourceProcessor):
+class DatabaseSingleMatchSelector(BaseDatabaseSourceSelector, ABC):
     """
-    Processor to crossmatch to sources in a database
+    Processor to import a single match from a database
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, max_num_results=1, **kwargs)
+
+    def update_dataframe(
+        self, candidate_table: pd.DataFrame, results: list[pd.DataFrame]
+    ) -> pd.DataFrame:
+        """
+        Update a dataframe with db results
+
+        :param candidate_table: pandas table
+        :param results: results from db query
+        :return: updated dataframe
+        """
+        assert len(results) == len(candidate_table)
+
+        new_cols = []
+        for res in results:
+            if len(res) > 0:
+                assert len(res) == 1
+                new_row = {x: res.iloc[0][x] for x in self.db_output_columns}
+
+            else:
+                new_row = {x: None for x in self.db_output_columns}
+
+            new_cols.append(new_row)
+
+        candidate_table = candidate_table.join(pd.DataFrame(new_cols))
+
+        return candidate_table
+
+
+class DatabaseMultimatchSelector(BaseDatabaseSourceSelector, ABC):
+    """
+    Processor to import multiple matches from a database
+    """
+
+    def __init__(self, *args, base_output_column: str = SOURCE_HISTORY_KEY, **kwargs):
+        self.base_output_column = base_output_column
+        super().__init__(*args, **kwargs)
+
+    def update_dataframe(
+        self,
+        candidate_table: pd.DataFrame,
+        results: list[pd.DataFrame],
+    ) -> pd.DataFrame:
+        """
+        Update a pandas dataframe with the number of matches
+
+        :param candidate_table: Pandas dataframe
+        :param results: db query results
+        :return: updated pandas dataframe
+        """
+        assert len(results) == len(candidate_table)
+        candidate_table[self.base_output_column] = [
+            x.to_dict(orient="records") for x in results
+        ]
+        return candidate_table
+
+
+class BaseSpatialCrossmatchSource(BaseDatabaseSourceSelector, ABC):
+    """
+    Processor to crossmatch to sources in a database using spatial search
     """
 
     def __init__(
@@ -212,7 +282,6 @@ class CrossmatchSourceWithDatabase(BaseDatabaseSourceSelector, BaseSourceProcess
         order_field_name: Optional[str] = None,
         order_ascending: bool = False,
         query_dist: bool = False,
-        output_df_colname: str = SOURCE_XMATCH_KEY,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -222,40 +291,20 @@ class CrossmatchSourceWithDatabase(BaseDatabaseSourceSelector, BaseSourceProcess
         self.order_field_name = order_field_name
         self.order_ascending = order_ascending
         self.query_dist = query_dist
-        self.output_df_colname = output_df_colname
-
-    def update_dataframe(
-        self,
-        candidate_table: pd.DataFrame,
-        results: list[pd.DataFrame],
-    ) -> pd.DataFrame:
-        """
-        Update a pandas dataframe with the number of previous detections
-
-        :param candidate_table: Pandas dataframe
-        :param results: db query results
-        :return: updated pandas dataframe
-        """
-        assert len(results) == len(candidate_table)
-        candidate_table[self.output_df_colname] = [
-            x.to_dict(orient="records") for x in results
-        ]
-
-        return candidate_table
 
     def get_source_crossmatch_constraints(
-        self, source: pd.Series
+        self, data: dict
     ) -> DBQueryConstraints:
         """
         Apply constraints to a single source, using q3c
 
-        :param source: Source
+        :param data: Dictionary containing source data
         :return: DBQueryConstraints
         """
         query_constraints = DBQueryConstraints()
         query_constraints.add_q3c_constraint(
-            ra=source["ra"],
-            dec=source["dec"],
+            ra=data["ra"],
+            dec=data["dec"],
             ra_field_name=self.ra_field_name,
             dec_field_name=self.dec_field_name,
             crossmatch_radius_arcsec=self.xmatch_radius_arcsec,
@@ -263,11 +312,33 @@ class CrossmatchSourceWithDatabase(BaseDatabaseSourceSelector, BaseSourceProcess
 
         return query_constraints
 
-    def get_constraints(self, source: pd.Series) -> DBQueryConstraints:
-        return self.get_source_crossmatch_constraints(source)
+    def get_constraints(self, data: dict) -> DBQueryConstraints:
+        return self.get_source_crossmatch_constraints(data)
 
 
-class DatabaseHistorySelector(CrossmatchSourceWithDatabase):
+class SingleSpatialCrossmatchSource(
+    BaseSpatialCrossmatchSource, DatabaseSingleMatchSelector
+):
+    """
+    Processor to import a single source from a database using spatial crossmatch
+    """
+
+
+class SpatialCrossmatchSourceWithDatabase(
+    BaseSpatialCrossmatchSource, DatabaseMultimatchSelector
+):
+    """
+    Processor to import multiple sources from a database using spatial crossmatch
+    """
+
+
+class SelectSourcesWithMetadata(DatabaseMultimatchSelector, BaseValuesCrossmatch):
+    """
+    Processor to import sources from a database using metadata values
+    """
+
+
+class DatabaseHistorySelector(SpatialCrossmatchSourceWithDatabase):
     """
     Processor to import previous detections of a source from a database
     """
@@ -284,16 +355,16 @@ class DatabaseHistorySelector(CrossmatchSourceWithDatabase):
         self.output_df_colname = SOURCE_HISTORY_KEY
         logger.info(f"Update db is {self.update_dataframe}")
 
-    def get_constraints(self, source: pd.Series) -> DBQueryConstraints:
-        query_constraints = self.get_source_crossmatch_constraints(source)
+    def get_constraints(self, data: dict) -> DBQueryConstraints:
+        query_constraints = self.get_source_crossmatch_constraints(data)
         query_constraints.add_constraint(
             column=self.time_field_name,
             comparison_type="<",
-            accepted_values=source[self.time_field_name],
+            accepted_values=data[self.time_field_name],
         )
         query_constraints.add_constraint(
             column=self.time_field_name,
             comparison_type=">=",
-            accepted_values=source[self.time_field_name] - self.history_duration_days,
+            accepted_values=data[self.time_field_name] - self.history_duration_days,
         )
         return query_constraints

--- a/mirar/processors/database/database_selector.py
+++ b/mirar/processors/database/database_selector.py
@@ -200,6 +200,7 @@ class BaseDatabaseSourceSelector(BaseDatabaseSelector, BaseSourceProcessor, ABC)
                 )
 
                 results.append(res)
+
             new_table = self.update_dataframe(candidate_table, results)
             source_table.set_data(new_table)
         return batch

--- a/mirar/processors/database/database_selector.py
+++ b/mirar/processors/database/database_selector.py
@@ -292,9 +292,7 @@ class BaseSpatialCrossmatchSource(BaseDatabaseSourceSelector, ABC):
         self.order_ascending = order_ascending
         self.query_dist = query_dist
 
-    def get_source_crossmatch_constraints(
-        self, data: dict
-    ) -> DBQueryConstraints:
+    def get_source_crossmatch_constraints(self, data: dict) -> DBQueryConstraints:
         """
         Apply constraints to a single source, using q3c
 

--- a/mirar/processors/sources/namer.py
+++ b/mirar/processors/sources/namer.py
@@ -117,14 +117,15 @@ class CandidateNamer(BaseDatabaseSourceSelector):
         for source_table in batch:
             sources = source_table.get_data()
 
-            assert SOURCE_NAME_KEY in sources.columns, "No cross-match in source table"
-
             names = []
 
             detection_time = Time(source_table[TIME_KEY])
             for ind, source in sources.iterrows():
 
-                source_name = source[SOURCE_NAME_KEY]
+                source_name = None
+
+                if SOURCE_NAME_KEY in source:
+                    source_name = source[SOURCE_NAME_KEY]
 
                 if pd.isnull(source_name):
                     source_name = self.get_next_name(

--- a/mirar/processors/sources/namer.py
+++ b/mirar/processors/sources/namer.py
@@ -4,15 +4,13 @@ Module containing a processor for assigning names to sources
 
 import logging
 
-import numpy as np
+import pandas as pd
 from astropy.time import Time
 from sqlalchemy import select, text
 
 from mirar.data import SourceBatch
 from mirar.database.transactions.select import run_select
-from mirar.paths import SOURCE_NAME_KEY, SOURCE_XMATCH_KEY, TIME_KEY
-from mirar.processors.base_processor import PrerequisiteError
-from mirar.processors.database import CrossmatchSourceWithDatabase
+from mirar.paths import SOURCE_NAME_KEY, TIME_KEY
 from mirar.processors.database.database_selector import BaseDatabaseSourceSelector
 
 logger = logging.getLogger(__name__)
@@ -119,40 +117,26 @@ class CandidateNamer(BaseDatabaseSourceSelector):
         for source_table in batch:
             sources = source_table.get_data()
 
-            assert (
-                SOURCE_XMATCH_KEY in sources.columns
-            ), "No candidate cross-match in source table"
+            assert SOURCE_NAME_KEY in sources.columns, "No cross-match in source table"
 
             names = []
 
             detection_time = Time(source_table[TIME_KEY])
             for ind, source in sources.iterrows():
-                if len(source[SOURCE_XMATCH_KEY]) > 0:
-                    source_name = source[SOURCE_XMATCH_KEY][0][self.db_name_field]
-                else:
+
+                source_name = source[SOURCE_NAME_KEY]
+
+                if pd.isnull(source_name):
                     source_name = self.get_next_name(
                         detection_time, last_name=self.lastname
                     )
                     self.lastname = source_name
-                logger.debug(f"Assigning name: {source_name} to source # {ind}.")
+                    logger.debug(f"Assigning name: {source_name} to source # {ind}.")
+                else:
+                    logger.debug(f"Source # {ind} already has a name: {source_name}.")
                 names.append(source_name)
 
             sources[self.db_name_field] = names
             source_table.set_data(sources)
 
         return batch
-
-    def check_prerequisites(
-        self,
-    ):
-        check = np.sum(
-            [isinstance(x, CrossmatchSourceWithDatabase) for x in self.preceding_steps]
-        )
-        if check < 1:
-            err = (
-                f"{self.__module__} requires {CrossmatchSourceWithDatabase} "
-                f"as a prerequisite. "
-                f"However, the following steps were found: {self.preceding_steps}."
-            )
-            logger.error(err)
-            raise PrerequisiteError(err)


### PR DESCRIPTION
This PR adds a new table for WINTER sources. Fix #732, fix #734. From now onwards:

- Source Names are assigned using the source table. New candidates are crossmatched to this.
- Each candidate has a sourceid foreign key. Many candidates to one source.
- The sourcetable has an average position. The winter pipeline will retrieve the full history and then update the position in the source table accordingly.
-  Databases are slightly reworked to reflect this. You can now do single spatial crossmatch, multiple spatial crossmatch, or query by parameters in the same way as images. 
- History is now assigned by querying the candidate table for candidates sharing a sourceid, NOT via spatial coordinates.

This is a breaking change, and is somewhat decoupled from the migration of the existing database which we will need to implement. My preference would be to somehow create a clean candidate table and source table, and then reingest old candidates in sequence to assign names correctly. I am just worried it'll undercut all the candidate scanning done so far.