### PR TITLE
Push to Fritz

### DIFF
--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -31,7 +31,7 @@ from mirar.pipelines.winter.config import (
     sextractor_reference_psf_phot_config,
     swarp_config_path,
     winter_avro_schema_path,
-    winter_preview_config,
+    winter_fritz_config,
 )
 from mirar.pipelines.winter.constants import NXSPLIT, NYSPLIT
 from mirar.pipelines.winter.generator import (
@@ -617,7 +617,7 @@ crossmatch_candidates = [
     ),
 ]
 
-load_history = [
+select_history = [
     SelectSourcesWithMetadata(
         db_query_columns=["sourceid"],
         db_table=Candidate,
@@ -652,7 +652,7 @@ name_candidates = (
         ),
         # Get all candidates associated with source
     ]
-    + load_history
+    + select_history
     + [
         # Update average ra and dec for source
         CustomSourceTableModifier(modifier_function=winter_source_entry_updater),
@@ -683,10 +683,11 @@ avro_export = [
 
 process_candidates = crossmatch_candidates + name_candidates + avro_export
 
+load_skyportal = [SourceLoader(input_dir_name="preskyportal")]
+
 send_to_skyportal = [
-    # SourceLoader(input_dir_name="preskyportal"),
     CustomSourceTableModifier(modifier_function=winter_skyportal_annotator),
-    SkyportalCandidateUploader(**winter_preview_config),
+    SkyportalCandidateUploader(**winter_fritz_config),
 ]
 
 # To make a mosaic by stacking all boards

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -31,6 +31,7 @@ from mirar.pipelines.winter.config import (
     sextractor_reference_psf_phot_config,
     swarp_config_path,
     winter_avro_schema_path,
+    winter_preview_config,
 )
 from mirar.pipelines.winter.constants import NXSPLIT, NYSPLIT
 from mirar.pipelines.winter.generator import (
@@ -58,6 +59,7 @@ from mirar.pipelines.winter.generator import (
     winter_reference_psf_phot_sextractor,
     winter_reference_psfex,
     winter_reference_sextractor,
+    winter_skyportal_annotator,
     winter_source_entry_updater,
     winter_stackid_annotator,
 )
@@ -117,7 +119,6 @@ from mirar.processors.photcal import ZPWithColorTermCalculator
 from mirar.processors.photcal.photcalibrator import PhotCalibrator
 from mirar.processors.photometry import AperturePhotometry, PSFPhotometry
 from mirar.processors.reference import GetReferenceImage, ProcessReference
-from mirar.processors.skyportal.client import SkyportalClient
 from mirar.processors.skyportal.skyportal_candidate import SkyportalCandidateUploader
 from mirar.processors.sources import (
     CandidateNamer,
@@ -616,29 +617,7 @@ crossmatch_candidates = [
     ),
 ]
 
-name_candidates = [
-    # Check if the source is already in the source table
-    SingleSpatialCrossmatchSource(
-        db_table=Source,
-        db_output_columns=["sourceid", SOURCE_NAME_KEY],
-        crossmatch_radius_arcsec=2.0,
-        ra_field_name="average_ra",
-        dec_field_name="average_dec",
-    ),
-    # Assign names to the new sources
-    CandidateNamer(
-        db_table=Source,
-        base_name=SOURCE_PREFIX,
-        name_start=NAME_START,
-        db_name_field=SOURCE_NAME_KEY,
-    ),
-    # Add the new sources to the source table
-    CustomSourceTableModifier(modifier_function=winter_new_source_updater),
-    DatabaseSourceInserter(
-        db_table=Source,
-        duplicate_protocol="ignore",
-    ),
-    # Get all candidates associated with source
+load_history = [
     SelectSourcesWithMetadata(
         db_query_columns=["sourceid"],
         db_table=Candidate,
@@ -646,20 +625,50 @@ name_candidates = [
         base_output_column=SOURCE_HISTORY_KEY,
         additional_query_constraints=winter_history_deprecated_constraint,
     ),
-    # Update average ra and dec for source
-    CustomSourceTableModifier(modifier_function=winter_source_entry_updater),
-    # Update sources in the source table
-    DatabaseSourceInserter(
-        db_table=Source,
-        duplicate_protocol="replace",
-    ),
-    # Add candidates in the candidate table
-    DatabaseSourceInserter(
-        db_table=Candidate,
-        duplicate_protocol="fail",
-    ),
-    SourceWriter(output_dir_name="preavro"),
 ]
+
+name_candidates = (
+    [
+        # Check if the source is already in the source table
+        SingleSpatialCrossmatchSource(
+            db_table=Source,
+            db_output_columns=["sourceid", SOURCE_NAME_KEY],
+            crossmatch_radius_arcsec=2.0,
+            ra_field_name="average_ra",
+            dec_field_name="average_dec",
+        ),
+        # Assign names to the new sources
+        CandidateNamer(
+            db_table=Source,
+            base_name=SOURCE_PREFIX,
+            name_start=NAME_START,
+            db_name_field=SOURCE_NAME_KEY,
+        ),
+        # Add the new sources to the source table
+        CustomSourceTableModifier(modifier_function=winter_new_source_updater),
+        DatabaseSourceInserter(
+            db_table=Source,
+            duplicate_protocol="ignore",
+        ),
+        # Get all candidates associated with source
+    ]
+    + load_history
+    + [
+        # Update average ra and dec for source
+        CustomSourceTableModifier(modifier_function=winter_source_entry_updater),
+        # Update sources in the source table
+        DatabaseSourceInserter(
+            db_table=Source,
+            duplicate_protocol="replace",
+        ),
+        # Add candidates in the candidate table
+        DatabaseSourceInserter(
+            db_table=Candidate,
+            duplicate_protocol="fail",
+        ),
+        SourceWriter(output_dir_name="preavro"),
+    ]
+)
 
 avro_export = [
     IPACAvroExporter(
@@ -675,17 +684,11 @@ avro_export = [
 process_candidates = crossmatch_candidates + name_candidates + avro_export
 
 send_to_skyportal = [
-    SourceLoader(input_dir_name="preskyportal"),
-    SkyportalCandidateUploader(
-        origin="WINTERTEST",
-        group_ids=[1076],
-        fritz_filter_id=1016,
-        instrument_id=1066,
-        stream_id=1008,
-        update_thumbnails=True,
-        skyportal_client=SkyportalClient(base_url="https://preview.fritz.science/api/"),
-    ),
+    # SourceLoader(input_dir_name="preskyportal"),
+    CustomSourceTableModifier(modifier_function=winter_skyportal_annotator),
+    SkyportalCandidateUploader(**winter_preview_config),
 ]
+
 # To make a mosaic by stacking all boards
 stack_boards = [
     ImageBatcher([TARGET_KEY]),

--- a/mirar/pipelines/winter/config/__init__.py
+++ b/mirar/pipelines/winter/config/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from fastavro.schema import load_schema
 
+from mirar.processors.skyportal.client import SkyportalClient
 from mirar.processors.utils.cal_hunter import CalRequirement
 
 PIPELINE_NAME = "winter"
@@ -85,3 +86,25 @@ winter_avro_schema_path = winter_file_dir.joinpath("avro_schema/winter.alert.avs
 winter_avro_schema = load_schema(winter_avro_schema_path)
 winter_prv_schema = winter_avro_schema["__named_schemas"]["winter.alert.prv_candidate"]
 prv_candidate_cols = [x["name"] for x in winter_prv_schema["fields"]]
+
+# To send to preview.fritz.science
+winter_preview_config = {
+    "origin": "mirar",
+    "group_ids": [1092],
+    "fritz_filter_id": 1018,
+    "instrument_id": 1066,
+    "stream_id": 1008,
+    "update_thumbnails": True,
+    "skyportal_client": SkyportalClient(base_url="https://preview.fritz.science/api/"),
+}
+
+# To send to fritz.science
+winter_fritz_config = {
+    "origin": "mirar",
+    "group_ids": [1092],
+    "fritz_filter_id": 1018,
+    "instrument_id": 1066,
+    "stream_id": 1008,
+    "update_thumbnails": True,
+    "skyportal_client": SkyportalClient(base_url="https://fritz.science/api/"),
+}

--- a/mirar/pipelines/winter/config/__init__.py
+++ b/mirar/pipelines/winter/config/__init__.py
@@ -101,10 +101,10 @@ winter_preview_config = {
 # To send to fritz.science
 winter_fritz_config = {
     "origin": "mirar",
-    "group_ids": [1092],
-    "fritz_filter_id": 1018,
-    "instrument_id": 1066,
-    "stream_id": 1008,
+    "group_ids": [1657],
+    "fritz_filter_id": 1185,
+    "instrument_id": 1087,
+    "stream_id": 1005,
     "update_thumbnails": True,
     "skyportal_client": SkyportalClient(base_url="https://fritz.science/api/"),
 }

--- a/mirar/pipelines/winter/constants.py
+++ b/mirar/pipelines/winter/constants.py
@@ -8,6 +8,14 @@ import pandas as pd
 
 winter_filters_map = {"Y": 1, "J": 2, "Hs": 3, "dark": 4}
 
+winter_inv_filters_map = {v: k for k, v in winter_filters_map.items()}
+
+sncosmo_filters = {
+    "y": "desy",
+    "j": "2massj",
+    "h": "2massh",
+}
+
 imgtype_dict = {
     "science": "SCIENCE",
     "bias": "CAL",

--- a/mirar/pipelines/winter/generator.py
+++ b/mirar/pipelines/winter/generator.py
@@ -660,6 +660,9 @@ def winter_skyportal_annotator(source_batch: SourceBatch) -> SourceBatch:
     for source_table in source_batch:
         src_df = source_table.get_data()
 
+        if "fid" not in src_df.columns:
+            src_df["fid"] = source_table["fid"]
+
         if SNCOSMO_KEY not in src_df.columns:
             sncosmo_fs = [
                 sncosmo_filters[winter_inv_filters_map[x].lower()]

--- a/mirar/pipelines/winter/generator.py
+++ b/mirar/pipelines/winter/generator.py
@@ -41,7 +41,11 @@ from mirar.pipelines.winter.config import (
     sextractor_reference_psf_phot_config,
     swarp_config_path,
 )
-from mirar.pipelines.winter.constants import winter_filters_map
+from mirar.pipelines.winter.constants import (
+    sncosmo_filters,
+    winter_filters_map,
+    winter_inv_filters_map,
+)
 from mirar.pipelines.winter.fourier_bkg_model import subtract_fourier_background_model
 from mirar.pipelines.winter.models import (
     DEFAULT_FIELD,
@@ -57,6 +61,7 @@ from mirar.processors.base_catalog_xmatch_processor import (
     default_image_sextractor_catalog_purifier,
 )
 from mirar.processors.photcal.photcalibrator import PhotCalibrator
+from mirar.processors.skyportal.skyportal_source import SNCOSMO_KEY
 from mirar.processors.split import SUB_ID_KEY
 from mirar.processors.utils.cal_hunter import CalRequirement
 from mirar.processors.utils.image_selector import select_from_images
@@ -640,6 +645,37 @@ def winter_candidate_avro_fields_calculator(source_table: SourceBatch) -> Source
         new_batch.append(source)
 
     return new_batch
+
+
+def winter_skyportal_annotator(source_table: SourceBatch) -> SourceBatch:
+    """
+    Function to update the candidate table with the skyportal fields
+
+    :param source_table: Original source table
+    :return: Updated source table
+    """
+    for source in source_table:
+        src_df = source.get_data()
+
+        if SNCOSMO_KEY not in src_df.columns:
+            sncosmo_fs = [
+                sncosmo_filters[winter_inv_filters_map[x].lower()]
+                for x in src_df["fid"]
+            ]
+            src_df[SNCOSMO_KEY] = sncosmo_fs
+
+        for hist_df in src_df[SOURCE_HISTORY_KEY]:
+            mjds = [Time(x, format="jd").mjd for x in hist_df["jd"]]
+            hist_df["mjd"] = mjds
+            sncosmo_fs = [
+                sncosmo_filters[winter_inv_filters_map[x].lower()]
+                for x in hist_df["fid"]
+            ]
+            hist_df[SNCOSMO_KEY] = sncosmo_fs
+
+        source.set_data(src_df)
+
+    return source_table
 
 
 def winter_candidate_quality_filterer(source_table: SourceBatch) -> SourceBatch:

--- a/mirar/pipelines/winter/generator.py
+++ b/mirar/pipelines/winter/generator.py
@@ -661,7 +661,7 @@ def winter_skyportal_annotator(source_batch: SourceBatch) -> SourceBatch:
         src_df = source_table.get_data()
 
         if "fid" not in src_df.columns:
-            src_df["fid"] = source_table["fid"]
+            src_df["fid"] = source_table["FID"]
 
         if SNCOSMO_KEY not in src_df.columns:
             sncosmo_fs = [

--- a/mirar/pipelines/winter/load_winter_image.py
+++ b/mirar/pipelines/winter/load_winter_image.py
@@ -37,6 +37,7 @@ from mirar.paths import (
 from mirar.pipelines.winter.constants import (
     imgtype_dict,
     palomar_observer,
+    sncosmo_filters,
     subdets,
     winter_filters_map,
 )
@@ -44,12 +45,6 @@ from mirar.pipelines.winter.models import DEFAULT_FIELD, default_program, itid_d
 from mirar.processors.skyportal import SNCOSMO_KEY
 
 logger = logging.getLogger(__name__)
-
-sncosmo_filters = {
-    "y": "desy",
-    "j": "2massj",
-    "h": "2massh",
-}
 
 
 def clean_header(header: fits.Header) -> fits.Header:

--- a/mirar/pipelines/winter/winter_pipeline.py
+++ b/mirar/pipelines/winter/winter_pipeline.py
@@ -21,8 +21,8 @@ from mirar.pipelines.winter.blocks import (
     imsub,
     load_calibrated,
     load_final_stack,
-    load_history,
     load_raw,
+    load_skyportal,
     load_test,
     mask_and_split,
     mosaic,
@@ -37,6 +37,7 @@ from mirar.pipelines.winter.blocks import (
     refbuild,
     reftest,
     save_raw,
+    select_history,
     select_split_subset,
     send_to_skyportal,
     stack_forced_photometry,
@@ -88,7 +89,11 @@ class WINTERPipeline(Pipeline):
         "realtime": realtime,
         "detect_candidates": load_final_stack + imsub + detect_candidates,
         "full_imsub": load_final_stack + imsub + detect_candidates + process_candidates,
-        "full": reduce + imsub + detect_candidates + process_candidates,
+        "full": reduce
+        + imsub
+        + detect_candidates
+        + process_candidates
+        + send_to_skyportal,
         "full_subset": reduce_unpacked + imsub + detect_candidates + process_candidates,
         "full_no_calhunter": reduce_no_calhunter
         + imsub
@@ -97,12 +102,12 @@ class WINTERPipeline(Pipeline):
         "focus_cals": focus_cals,
         "mosaic": mosaic,
         "log": load_raw + extract_all + csvlog,
-        "send_skyportal": send_to_skyportal,
+        "skyportal": load_skyportal + send_to_skyportal,
         "name_candidates": name_candidates,
         "diff_forced_phot": diff_forced_photometry,
         "stack_forced_phot": stack_forced_photometry,
         "detrend": unpack_all + detrend_unpacked,
-        "send_with_history": load_history + send_to_skyportal,
+        "send_with_history": select_history + send_to_skyportal,
     }
 
     non_linear_level = 40000.0

--- a/mirar/pipelines/winter/winter_pipeline.py
+++ b/mirar/pipelines/winter/winter_pipeline.py
@@ -21,6 +21,7 @@ from mirar.pipelines.winter.blocks import (
     imsub,
     load_calibrated,
     load_final_stack,
+    load_history,
     load_raw,
     load_test,
     mask_and_split,
@@ -101,6 +102,7 @@ class WINTERPipeline(Pipeline):
         "diff_forced_phot": diff_forced_photometry,
         "stack_forced_phot": stack_forced_photometry,
         "detrend": unpack_all + detrend_unpacked,
+        "send_with_history": load_history + send_to_skyportal,
     }
 
     non_linear_level = 40000.0

--- a/mirar/processors/avro/base_avro_exporter.py
+++ b/mirar/processors/avro/base_avro_exporter.py
@@ -98,6 +98,7 @@ class BaseAvroExporter(BaseSourceProcessor):
         :param schema: Schema of the records
         :return: None
         """
+        raise NotImplementedError
 
     def broadcast_single_alert_packet(self, packet, schema, topic_name):
         """

--- a/mirar/processors/avro/ipac_avro_exporter.py
+++ b/mirar/processors/avro/ipac_avro_exporter.py
@@ -12,7 +12,7 @@ import pandas as pd
 from fastavro.types import Schema
 
 from mirar.data import SourceTable
-from mirar.paths import BASE_NAME_KEY
+from mirar.paths import BASE_NAME_KEY, SOURCE_HISTORY_KEY
 from mirar.processors.avro.base_avro_exporter import BaseAvroExporter
 
 logger = logging.getLogger(__name__)
@@ -87,26 +87,30 @@ class IPACAvroExporter(BaseAvroExporter):
         :param source_table: input source table
         :return: list of avro alerts
         """
+
         new_alerts = []
 
         metadata = source_table.get_metadata()
 
         for _, row in source_table.get_data().iterrows():
+
             alert = self.fill_schema(self.alert_schema, row, metadata)
             candidate = self.fill_schema(self.candidate_schema, row, metadata)
             alert["candidate"] = candidate
 
             prv_candidates = []
-            if "prv_candidates" in row.keys():
-                prv_cands = pd.DataFrame(row["prv_candidates"])
-                if len(prv_candidates) > 0:
-                    for _, prv_row in prv_cands.iterrows():
-                        prv_dict = {}
-                        for key in self.prv_schema["fields"]:
-                            if key in prv_row.keys():
-                                prv_dict[key] = prv_row[key]
-                        prv_candidates.append(prv_dict)
-            alert["prv_candidate"] = prv_candidates
+
+            if SOURCE_HISTORY_KEY in row.keys():
+                prv_cands = row[SOURCE_HISTORY_KEY]
+                if len(prv_cands) > 0:
+
+                    keys = list(str(x["name"]) for x in self.prv_schema["fields"])
+
+                    prv_cands = prv_cands.loc[:, keys]
+
+                    prv_candidates = prv_cands.to_dict(orient="records")
+
+            alert["prv_candidates"] = prv_candidates
 
             new_alerts.append(alert)
 

--- a/mirar/processors/database/database_selector.py
+++ b/mirar/processors/database/database_selector.py
@@ -264,9 +264,7 @@ class DatabaseMultimatchSelector(BaseDatabaseSourceSelector, ABC):
         :return: updated pandas dataframe
         """
         assert len(results) == len(candidate_table)
-        candidate_table[self.base_output_column] = [
-            x.to_dict(orient="records") for x in results
-        ]
+        candidate_table[self.base_output_column] = results
         return candidate_table
 
 

--- a/mirar/processors/skyportal/skyportal_candidate.py
+++ b/mirar/processors/skyportal/skyportal_candidate.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from astropy.time import Time
 
-from mirar.paths import PACKAGE_NAME, SOURCE_NAME_KEY, __version__
+from mirar.paths import SOURCE_NAME_KEY
 from mirar.processors.skyportal.skyportal_source import SkyportalSourceUploader
 
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
             "filter_ids": [self.fritz_filter_id],
             "passing_alert_id": self.fritz_filter_id,
             "passed_at": Time(datetime.utcnow()).isot,
-            "origin": f"{PACKAGE_NAME}:{__version__}",
+            "origin": self.origin,
         }
 
         logger.debug(

--- a/mirar/processors/skyportal/skyportal_candidate.py
+++ b/mirar/processors/skyportal/skyportal_candidate.py
@@ -249,8 +249,6 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
                     logger.error(
                         f"Failed to get source groups info on {alert[SOURCE_NAME_KEY]}"
                     )
-            else:  # exists in SkyPortal but NOT saved as a source
-                self.skyportal_post_source(alert)
 
             # post alert photometry in single call to /api/photometry
             logger.debug(f"Using stream_id={self.stream_id}")

--- a/mirar/processors/skyportal/skyportal_source.py
+++ b/mirar/processors/skyportal/skyportal_source.py
@@ -46,6 +46,9 @@ class SkyportalSourceUploader(BaseSourceProcessor):
         self.instrument_id = instrument_id
         self.origin = origin  # used for sending updates to Fritz
         self.update_thumbnails = update_thumbnails
+
+        print("update_thumbnails: ", update_thumbnails)
+
         self.skyportal_client = skyportal_client
 
     def _apply_to_sources(
@@ -65,7 +68,7 @@ class SkyportalSourceUploader(BaseSourceProcessor):
 
             candidate_df["mjd"] = Time(metadata[TIME_KEY]).mjd
             for _, src in candidate_df.iterrows():
-                super_dict = self.generate_super_dict(metadata, src)
+                super_dict = self.generate_super_dict(metadata, src.fillna(""))
                 self.export_to_skyportal(deepcopy(super_dict))
 
         return batch
@@ -157,7 +160,13 @@ class SkyportalSourceUploader(BaseSourceProcessor):
             logger.debug(
                 f"Making {instrument_type} thumbnail for {alert[SOURCE_NAME_KEY]} "
             )
-            thumb = self.make_thumbnail(alert, ttype, instrument_type)
+            try:
+                thumb = self.make_thumbnail(alert, ttype, instrument_type)
+            except KeyError:
+                logger.error(
+                    f"Missing {instrument_type} cutout for {alert[SOURCE_NAME_KEY]}"
+                )
+                continue
 
             logger.debug(
                 f"Posting {instrument_type} thumbnail for {alert[SOURCE_NAME_KEY]} "
@@ -201,22 +210,16 @@ class SkyportalSourceUploader(BaseSourceProcessor):
                 prv_detections = pd.DataFrame.from_records(source[SOURCE_HISTORY_KEY])
 
                 for _, row in prv_detections.iterrows():
-                    try:
-                        photometry_table.append(
-                            {
-                                "mjd": row["mjd"],
-                                "mag": row["magpsf"],
-                                "magerr": row["sigmapsf"],
-                                "filter": row[SNCOSMO_KEY],
-                                "ra": row["ra"],
-                                "dec": row["dec"],
-                            }
-                        )
-                    except KeyError:
-                        logger.warning(
-                            f"Missing photometry information for previous "
-                            f"detection of {source[SOURCE_NAME_KEY]}"
-                        )
+                    photometry_table.append(
+                        {
+                            "mjd": row["mjd"],
+                            "mag": row["magpsf"],
+                            "magerr": row["sigmapsf"],
+                            "filter": row[SNCOSMO_KEY],
+                            "ra": row["ra"],
+                            "dec": row["dec"],
+                        }
+                    )
 
         df_photometry = pd.DataFrame(photometry_table)
 

--- a/mirar/processors/skyportal/skyportal_source.py
+++ b/mirar/processors/skyportal/skyportal_source.py
@@ -46,9 +46,6 @@ class SkyportalSourceUploader(BaseSourceProcessor):
         self.instrument_id = instrument_id
         self.origin = origin  # used for sending updates to Fritz
         self.update_thumbnails = update_thumbnails
-
-        print("update_thumbnails: ", update_thumbnails)
-
         self.skyportal_client = skyportal_client
 
     def _apply_to_sources(


### PR DESCRIPTION
This PR switches on candidate pushing to fritz if ndet > 1.

It sets up a config entry for both preview and fritz.science. It gives history a named entry in blocks (but order in processing unchanged).

It adds a new WINTER configuration:   "send_with_history": select_history + send_to_skyportal. This can be used to push database-loaded candidate lists into Fritz (see winterdrb for an example).

It moves the sncosmo map to constants, and applies it to both candidates and history.

 