### PR TITLE
Put pipeversion into exposures

### DIFF
--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -216,7 +216,7 @@ load_raw = [
 
 extract_all = [
     ImageBatcher("UTCTIME"),
-    DatabaseImageBatchInserter(db_table=Exposure, duplicate_protocol="ignore"),
+    DatabaseImageBatchInserter(db_table=Exposure, duplicate_protocol="replace"),
     ImageSelector((OBSCLASS_KEY, ["dark", "science", "flat"])),
 ]
 

--- a/mirar/pipelines/winter/models/_exposures.py
+++ b/mirar/pipelines/winter/models/_exposures.py
@@ -52,6 +52,7 @@ class ExposuresTable(WinterBase):  # pylint: disable=too-few-public-methods
     )
     expid = Column(BigInteger, primary_key=False, unique=True, autoincrement=False)
     pipeversion = Column(VARCHAR(10), nullable=True, default=None)
+    lastmodified = Column(DateTime(timezone=True))
     # Deterministic ID of exposure
 
     fid: Mapped[int] = mapped_column(ForeignKey("filters.fid"))
@@ -147,6 +148,16 @@ class Exposure(BaseDB):
         :return: version of the pipeline
         """
         return __version__
+
+    @computed_field
+    @property
+    def lastmodified(self) -> datetime:
+        """
+        Returns the current date and time
+
+        :return: current date and time
+        """
+        return datetime.now()
 
     def insert_entry(
         self, duplicate_protocol: str, returning_key_names=None

--- a/mirar/pipelines/winter/models/_exposures.py
+++ b/mirar/pipelines/winter/models/_exposures.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 from typing import ClassVar
 
 import pandas as pd
-from pydantic import Field
+from pydantic import Field, computed_field
 from sqlalchemy import (  # event,
     VARCHAR,
     BigInteger,
@@ -24,6 +24,7 @@ from wintertoo.data import MAX_TARGNAME_LEN
 from mirar.database.base_model import BaseDB, alt_field, az_field, dec_field, ra_field
 from mirar.database.constraints import DBQueryConstraints
 from mirar.database.transactions import select_from_table
+from mirar.paths import __version__
 from mirar.pipelines.winter.models._fields import FieldsTable, fieldid_field
 from mirar.pipelines.winter.models._filters import FiltersTable, fid_field
 from mirar.pipelines.winter.models._img_type import ImgTypesTable
@@ -50,6 +51,7 @@ class ExposuresTable(WinterBase):  # pylint: disable=too-few-public-methods
         primary_key=True,
     )
     expid = Column(BigInteger, primary_key=False, unique=True, autoincrement=False)
+    pipeversion = Column(VARCHAR(10), nullable=True, default=None)
     # Deterministic ID of exposure
 
     fid: Mapped[int] = mapped_column(ForeignKey("filters.fid"))
@@ -135,6 +137,16 @@ class Exposure(BaseDB):
     dec: float = dec_field
     altitude: float = alt_field
     azimuth: float = az_field
+
+    @computed_field
+    @property
+    def pipeversion(self) -> str:
+        """
+        Returns the version of the pipeline used to process the exposure
+
+        :return: version of the pipeline
+        """
+        return __version__
 
     def insert_entry(
         self, duplicate_protocol: str, returning_key_names=None

--- a/mirar/processors/database/database_inserter.py
+++ b/mirar/processors/database/database_inserter.py
@@ -119,7 +119,10 @@ class DatabaseImageBatchInserter(DatabaseImageInserter):
 
     def _apply_to_images(self, batch: ImageBatch) -> ImageBatch:
         column_names = [
-            x for x in self.db_table.__dict__["__annotations__"] if x != "sql_model"
+            x
+            for x in self.db_table.__dict__["__annotations__"]
+            if (x != "sql_model")
+            & (x not in self.db_table.model_computed_fields.keys())
         ]
 
         for column in column_names:
@@ -147,6 +150,7 @@ class DatabaseImageBatchInserter(DatabaseImageInserter):
         val_dict = {key.lower(): image[key] for key in image.keys()}
 
         new = self.db_table(**val_dict)
+
         res = new.insert_entry(duplicate_protocol=self.duplicate_protocol)
 
         assert len(res) == 1


### PR DESCRIPTION
Adds pipeline version into exposures table. No need to annotate it explicitly in the image headers. Instead the pydantic model calculates it automatically.

Fix #775 