### PR TITLE
Catch corrupted images, and add readoutm/readoutv to db

### DIFF
--- a/mirar/database/base_model.py
+++ b/mirar/database/base_model.py
@@ -224,18 +224,26 @@ class BaseDB(PydanticBase):
 
         assert len(available_unique_keys) > 0
 
-        constraints = DBQueryConstraints(
-            columns=[x.name for x in available_unique_keys],
-            accepted_values=[self.model_dump()[x.name] for x in available_unique_keys],
-        )
+        valid_constraint = None
 
-        matches = select_from_table(
-            db_constraints=constraints,
-            sql_table=self.sql_model,
-        )
+        for key in available_unique_keys:
+            constraints = DBQueryConstraints(
+                columns=[key.name],
+                accepted_values=[self.model_dump()[key.name]],
+            )
+            matches = select_from_table(
+                db_constraints=constraints,
+                sql_table=self.sql_model,
+            )
+            if len(matches) == 1:
+                valid_constraint = constraints
+                break
 
-        if len(matches) == 0:
-            err = f"No matches found for {self.model_dump()} in {self.sql_model}."
+        if valid_constraint is None:
+            err = (
+                f"No matches found for {self.model_dump()} in {self.sql_model}. "
+                f"Tried {available_unique_keys}"
+            )
             logger.error(err)
             raise DatabaseUpdateError(err)
 
@@ -249,7 +257,7 @@ class BaseDB(PydanticBase):
         _update_database_entry(
             update_dict=update_dict,
             sql_table=self.sql_model,
-            db_constraints=constraints,
+            db_constraints=valid_constraint,
         )
 
     def update_entry(self, update_keys=None):

--- a/mirar/pipelines/summer/models/_raw.py
+++ b/mirar/pipelines/summer/models/_raw.py
@@ -27,9 +27,9 @@ class RawTable(SummerBase):  # pylint: disable=too-few-public-methods
         Integer,
         Sequence(start=1, name="raw_urawid_seq"),
         autoincrement=True,
-        unique=True,
+        primary_key=True,
     )
-    rawid = Column(Double, primary_key=True, autoincrement=False)
+    rawid = Column(Double, primary_key=False, unique=True, autoincrement=False)
     proc: Mapped["ProcTable"] = relationship(back_populates="raw_ids")
 
     uexpid: Mapped[int] = mapped_column(ForeignKey("exposures.uexpid"))

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -240,6 +240,8 @@ csvlog = [
             "DECDEG",
             "T_ROIC",
             "FIELDID",
+            "READOUTM",
+            "READOUTV",
         ]
     ),
 ]

--- a/mirar/pipelines/winter/models/_exposures.py
+++ b/mirar/pipelines/winter/models/_exposures.py
@@ -73,6 +73,9 @@ class ExposuresTable(WinterBase):  # pylint: disable=too-few-public-methods
     targname = Column(VARCHAR(MAX_TARGNAME_LEN), nullable=True)
     rawpath = Column(VARCHAR(255), unique=True)
 
+    readoutm = Column(VARCHAR(20), nullable=True)
+    readoutv = Column(VARCHAR(10), nullable=True)
+
     utctime = Column(DateTime(timezone=True))
 
     exptime = Column(Float, nullable=False)
@@ -119,6 +122,8 @@ class Exposure(BaseDB):
         min_length=0, max_length=MAX_TARGNAME_LEN, default=None
     )
     rawpath: str = Field(min_length=1)
+    readoutm: str | None = Field()
+    readoutv: str | None = Field()
 
     utctime: datetime = Field()
     exptime: float = Field(ge=0)

--- a/mirar/pipelines/winter/models/_exposures.py
+++ b/mirar/pipelines/winter/models/_exposures.py
@@ -122,8 +122,8 @@ class Exposure(BaseDB):
         min_length=0, max_length=MAX_TARGNAME_LEN, default=None
     )
     rawpath: str = Field(min_length=1)
-    readoutm: str | None = Field()
-    readoutv: str | None = Field()
+    readoutm: str | None = Field(default=None)
+    readoutv: str | None = Field(default=None)
 
     utctime: datetime = Field()
     exptime: float = Field(ge=0)


### PR DESCRIPTION
This PR loads images much more carefully. It specifically runs them through clean_header multiple times, because some information is duplicated in the primary header and secondary header. In that case, fixes to the primary header were not previously propagated. It handles corrupted images more carefully, so they are now loaded and logged but the pipeline can otherwise run.

It also adds a new check to make sure the DB update function is actually updating at least one entry.

This PR also now incorporates the new readoutm/readoutv into the database (default None), which will help a ton with book-keeping. Since it adds new DB columns, this is a major/breaking change for WINTER.