### PR TITLE
Add support for ARI Gaia catalog, closes #847

### DIFF
--- a/mirar/catalog/gaia.py
+++ b/mirar/catalog/gaia.py
@@ -10,6 +10,7 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astroquery.gaia import Gaia
+from astroquery.utils.tap.core import TapPlus
 
 from mirar.catalog.base_catalog import BaseCatalog
 from mirar.utils.ldac_tools import get_table_from_ldac
@@ -81,36 +82,66 @@ class Gaia2Mass(BaseCatalog):
         self,
         ra_deg: float,
         dec_deg: float,
+        use_ari: Optional[bool] = False,
     ) -> astropy.table.Table:
         logger.debug(
             f"Querying 2MASS - Gaia cross-match around RA {ra_deg:.4f}, "
             f"Dec {dec_deg:.4f} with a radius of {self.search_radius_arcmin:.4f} arcmin"
         )
 
-        cmd = (
-            f"SELECT * FROM gaiadr2.gaia_source AS g, "
-            f"gaiadr2.tmass_best_neighbour AS tbest, "
-            f"gaiadr1.tmass_original_valid AS tmass "
-            f"WHERE g.source_id = tbest.source_id "
-            f"AND tbest.tmass_oid = tmass.tmass_oid "
-            f"AND CONTAINS(POINT('ICRS', g.ra, g.dec), "
-            f"CIRCLE('ICRS', {ra_deg:.4f}, {dec_deg:.4f}, "
-            f"{self.search_radius_arcmin / 60:.4f}))=1 "
-            f"AND tmass.{self.filter_name}_m > {self.min_mag:.2f} "
-            f"AND tmass.{self.filter_name}_m < {self.max_mag:.2f} "
-            f"AND tbest.number_of_mates=0 "
-            f"AND tbest.number_of_neighbours=1;"
-        )
+        if not use_ari:
+            cmd = (
+                f"SELECT * FROM gaiadr2.gaia_source AS g, "
+                f"gaiadr2.tmass_best_neighbour AS tbest, "
+                f"gaiadr1.tmass_original_valid AS tmass "
+                f"WHERE g.source_id = tbest.source_id "
+                f"AND tbest.tmass_oid = tmass.tmass_oid "
+                f"AND CONTAINS(POINT('ICRS', g.ra, g.dec), "
+                f"CIRCLE('ICRS', {ra_deg:.4f}, {dec_deg:.4f}, "
+                f"{self.search_radius_arcmin / 60:.4f}))=1 "
+                f"AND tmass.{self.filter_name}_m > {self.min_mag:.2f} "
+                f"AND tmass.{self.filter_name}_m < {self.max_mag:.2f} "
+                f"AND tbest.number_of_mates=0 "
+                f"AND tbest.number_of_neighbours=1;"
+            )
 
-        job = Gaia.launch_job_async(cmd, dump_to_file=False)
-        src_list = job.get_results()
-        src_list["ph_qual"] = src_list["ph_qual"].astype(str)
-        src_list["ra_errdeg"] = src_list["ra_error"] / 3.6e6
-        src_list["dec_errdeg"] = src_list["dec_error"] / 3.6e6
-        src_list["FLAGS"] = 0
-        src_list["magnitude"] = src_list[f"{self.filter_name.lower()}_m"]
-        src_list["magnitude_err"] = src_list[f"{self.filter_name.lower()}_msigcom"]
-        logger.debug(f"Found {len(src_list)} sources in Gaia")
+            job = Gaia.launch_job_async(cmd, dump_to_file=False)
+            src_list = job.get_results()
+            src_list["ph_qual"] = src_list["ph_qual"].astype(str)
+            src_list["ra_errdeg"] = src_list["ra_error"] / 3.6e6
+            src_list["dec_errdeg"] = src_list["dec_error"] / 3.6e6
+            src_list["FLAGS"] = 0
+            src_list["magnitude"] = src_list[f"{self.filter_name.lower()}_m"]
+            src_list["magnitude_err"] = src_list[f"{self.filter_name.lower()}_msigcom"]
+            logger.debug(f"Found {len(src_list)} sources in Gaia")
+
+        else:
+            ari_url = "https://gaia.ari.uni-heidelberg.de/tap"
+            logger.debug(f"Using the ARI Gaia server at {ari_url}")
+            gaia = TapPlus(url=ari_url)
+            cmd = (
+                f"SELECT * FROM gaiadr2.gaia_source AS g, "
+                f"gaiadr2.tmass_best_neighbour AS tbest, "
+                f"extcat.twomass AS tmass "
+                f"WHERE g.source_id = tbest.source_id "
+                f"AND tbest.tmass_oid = tmass.pts_key "
+                f"AND CONTAINS(POINT('ICRS', g.ra, g.dec), "
+                f"CIRCLE('ICRS', {ra_deg:.4f}, {dec_deg:.4f}, "
+                f"{self.search_radius_arcmin / 60:.4f}))=1 "
+                f"AND tmass.{self.filter_name}mag > {self.min_mag:.2f} "
+                f"AND tmass.{self.filter_name}mag < {self.max_mag:.2f} "
+                f"AND tbest.number_of_mates=0 "
+                f"AND tbest.number_of_neighbours=1;"
+            )
+            job = gaia.launch_job_async(cmd)
+            src_list = job.get_results()
+            src_list["ph_qual"] = src_list["qflg"].astype(str)
+            src_list["ra_errdeg"] = src_list["ra_error"] / 3.6e6
+            src_list["dec_errdeg"] = src_list["dec_error"] / 3.6e6
+            src_list["FLAGS"] = 0
+            src_list["magnitude"] = src_list[f"{self.filter_name.lower()}mag"]
+            src_list["magnitude_err"] = src_list[f"e_{self.filter_name.lower()}mag"]
+            logger.debug(f"Found {len(src_list)} sources in Gaia")
 
         # Convert to AB magnitudes
 

--- a/mirar/catalog/gaia.py
+++ b/mirar/catalog/gaia.py
@@ -124,7 +124,7 @@ class Gaia2Mass(BaseCatalog):
                 f"gaiadr2.tmass_best_neighbour AS tbest, "
                 f"extcat.twomass AS tmass "
                 f"WHERE g.source_id = tbest.source_id "
-                f"AND tbest.tmass_oid = tmass.pts_key "
+                f"AND tbest.original_ext_source_id = tmass.mainid "
                 f"AND CONTAINS(POINT('ICRS', g.ra, g.dec), "
                 f"CIRCLE('ICRS', {ra_deg:.4f}, {dec_deg:.4f}, "
                 f"{self.search_radius_arcmin / 60:.4f}))=1 "


### PR DESCRIPTION
Closes #847 

This adds support for querying the ARI Gaia server. Unfortunately, the available 2MASS catalog is not identical to that on the ESA server. [Here](https://gaia.ari.uni-heidelberg.de/tap/tables) (scroll down to extcat, then twomass) are the table definitions. The notable and relevant differences are, first assuming that ESA's `gaiadr1.tmass_original_valid` is the same as ARI's `extcat.twomass`, 

- `tmass_oid` -> `pts_key`
- `{filter}_m` -> `{filter}mag`
- `{filter}_msigcom` -> `e_{filter}mag`
- `ph_qual` -> `qflg`

I _think_ these are the same, but without access to the ESA server (downtime until April 23), it is difficult to know for sure. We can cross-check once the ESA server comes back up, upon which this falling back to ARI will be an option for future ESA downtimes.
