### PR TITLE
Swap Zenodo reference to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Modular Image Reduction and Analysis Resource (MIRAR)
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10888437.svg)](https://doi.org/10.5281/zenodo.10888437)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10888436.svg)](https://doi.org/10.5281/zenodo.10888436)
 [![PyPI version](https://badge.fury.io/py/mirar.svg)](https://badge.fury.io/py/mirar)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/winter-telescope/mirar/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/winter-telescope/mirar/actions/workflows/continuous_integration.yml)
@@ -14,4 +14,4 @@ Open-source modular python package for astronomy image reduction, created by [@r
 
 Check out our [documentation](https://mirar.readthedocs.io/en/latest/?badge=latest) to learn more.
 
-If you use MIRAR in your research, please cite the software using the Zenodo DOI/auto-generated reference: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10888437.svg)](https://doi.org/10.5281/zenodo.10888437)
+If you use MIRAR in your research, please cite the software using the Zenodo DOI/auto-generated reference: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10888436.svg)](https://doi.org/10.5281/zenodo.10888436)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,8 +14,8 @@ It was created by `Robert Stein <https://robertdstein.github.io/>`_ and
 If you make use of mirar in your research, please cite the version using
 the DOI provided by Zenodo:
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10888437.svg
-  :target: https://doi.org/10.5281/zenodo.10888437
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10888436.svg
+  :target: https://doi.org/10.5281/zenodo.10888436
 
 
 Contents


### PR DESCRIPTION
Previously Zenodo DOI was accidentally set to a static version. Now using the dynamic "latest version" DOI.