### PR TITLE
Fix history/naming

### DIFF
--- a/mirar/paths.py
+++ b/mirar/paths.py
@@ -20,11 +20,10 @@ __version__ = metadata.version(__package__)
 doc_dir = base_code_dir.joinpath("docs/")
 
 # Load environment variables for .env file
-variables_loaded = dotenv.load_dotenv()
+VARIABLES_LOADED = dotenv.load_dotenv()
 
-if variables_loaded:
-    info = "Environment variables were automatically loaded from .env file."
-    logger.info(info)
+if VARIABLES_LOADED:
+    logger.info("Environment variables were automatically loaded from .env file.")
 
 _n_cpu = os.cpu_count()
 if _n_cpu is None:
@@ -344,6 +343,13 @@ core_fields = [
     RAW_IMG_KEY,
     BASE_NAME_KEY,
     EXPTIME_KEY,
+]
+
+core_source_fields = [
+    CAND_RA_KEY,
+    CAND_DEC_KEY,
+    SOURCE_NAME_KEY,
+    SOURCE_HISTORY_KEY,
 ]
 
 MONITOR_EMAIL_KEY = "WATCHDOG_EMAIL"

--- a/mirar/pipelines/winter/winter_pipeline.py
+++ b/mirar/pipelines/winter/winter_pipeline.py
@@ -95,7 +95,11 @@ class WINTERPipeline(Pipeline):
         "reftest": reftest,
         "only_ref": only_ref,
         "realtime": realtime,
-        "detect_candidates": load_final_stack + imsub + detect_candidates,
+        "detect_candidates": load_final_stack
+        + imsub
+        + detect_candidates
+        + process_candidates
+        + avro_broadcast,
         "full_imsub": load_final_stack
         + imsub
         + detect_candidates

--- a/mirar/pipelines/wirc/blocks.py
+++ b/mirar/pipelines/wirc/blocks.py
@@ -247,6 +247,9 @@ process_candidates = [
     XMatch(catalog=TMASS(num_sources=3, search_radius_arcmin=0.5)),
     XMatch(catalog=PS1(num_sources=3, search_radius_arcmin=0.5)),
     SourceWriter(output_dir_name="kowalski"),
+    HeaderAnnotator(input_keys=[LATEST_SAVE_KEY], output_key="diffimgname"),
+    HeaderAnnotator(input_keys=[SCI_IMG_KEY], output_key="sciimgname"),
+    HeaderAnnotator(input_keys=[REF_IMG_KEY], output_key="refimgname"),
     CandidateNamer(
         db_table=Candidate,
         base_name=CANDIDATE_PREFIX,
@@ -260,10 +263,7 @@ process_candidates = [
         db_table=Candidate,
         db_output_columns=[SOURCE_NAME_KEY] + prv_candidate_cols,
     ),
-    HeaderAnnotator(input_keys=[LATEST_SAVE_KEY], output_key="diffimgname"),
-    HeaderAnnotator(input_keys=[SCI_IMG_KEY], output_key="sciimgname"),
-    HeaderAnnotator(input_keys=[REF_IMG_KEY], output_key="refimgname"),
-    DatabaseSourceInserter(db_table=Candidate, duplicate_protocol="fail"),
+    DatabaseSourceInserter(db_table=Candidate, duplicate_protocol="replace"),
     SourceWriter(output_dir_name="candidates"),
     # EdgeCandidatesMask(edge_boundary_size=100)
     # FilterCandidates(),

--- a/mirar/pipelines/wirc/blocks.py
+++ b/mirar/pipelines/wirc/blocks.py
@@ -53,10 +53,7 @@ from mirar.processors.avro import IPACAvroExporter
 from mirar.processors.csvlog import CSVLog
 from mirar.processors.dark import DarkCalibrator
 from mirar.processors.database.database_inserter import DatabaseSourceInserter
-from mirar.processors.database.database_selector import (
-    DatabaseHistorySelector,
-    SpatialCrossmatchSourceWithDatabase,
-)
+from mirar.processors.database.database_selector import DatabaseHistorySelector
 from mirar.processors.flat import SkyFlatCalibrator
 from mirar.processors.mask import (
     MaskAboveThreshold,
@@ -250,16 +247,12 @@ process_candidates = [
     XMatch(catalog=TMASS(num_sources=3, search_radius_arcmin=0.5)),
     XMatch(catalog=PS1(num_sources=3, search_radius_arcmin=0.5)),
     SourceWriter(output_dir_name="kowalski"),
-    SpatialCrossmatchSourceWithDatabase(
-        db_table=Candidate,
-        db_output_columns=[SOURCE_NAME_KEY],
-        crossmatch_radius_arcsec=2.0,
-        max_num_results=1,
-    ),
     CandidateNamer(
         db_table=Candidate,
         base_name=CANDIDATE_PREFIX,
         name_start=NAME_START,
+        db_output_columns=[SOURCE_NAME_KEY],
+        crossmatch_radius_arcsec=2.0,
     ),
     DatabaseHistorySelector(
         crossmatch_radius_arcsec=2.0,

--- a/mirar/processors/base_processor.py
+++ b/mirar/processors/base_processor.py
@@ -25,7 +25,7 @@ from mirar.errors import (
     NoncriticalProcessingError,
     ProcessorError,
 )
-from mirar.io import open_fits, save_fits
+from mirar.io import MissingCoreFieldError, open_fits, save_fits
 from mirar.paths import (
     BASE_NAME_KEY,
     CAL_OUTPUT_SUB_DIR,
@@ -33,6 +33,7 @@ from mirar.paths import (
     PACKAGE_NAME,
     PROC_HISTORY_KEY,
     RAW_IMG_KEY,
+    core_source_fields,
     get_mask_path,
     get_output_path,
     max_n_cpu,
@@ -535,6 +536,15 @@ class BaseSourceGenerator(CleanupProcessor, ImageHandler, ABC):
         if len(source_batch) == 0:
             msg = "No sources found in image batch"
             logger.warning(msg)
+
+        for batch in source_batch:
+            cols = batch.get_data().columns
+            for field in core_source_fields:
+                if field not in cols:
+                    raise MissingCoreFieldError(
+                        f"Field {field} not found in source table. "
+                        f"Available fields are {cols}."
+                    )
 
         return source_batch
 

--- a/mirar/processors/csvlog.py
+++ b/mirar/processors/csvlog.py
@@ -32,6 +32,7 @@ class CSVLog(BaseImageProcessor):
         export_keys: Optional[list[str]] = None,
         output_sub_dir: str = "",
         output_base_dir: Optional[str] = None,
+        output_name: str = "log",
     ):
         super().__init__()
         if export_keys is None:
@@ -39,6 +40,7 @@ class CSVLog(BaseImageProcessor):
         self.export_keys = export_keys
         self.output_sub_dir = output_sub_dir
         self.output_base_dir = output_base_dir
+        self.output_name = output_name
         self.all_rows = []
 
     def __str__(self) -> str:
@@ -51,9 +53,9 @@ class CSVLog(BaseImageProcessor):
         """
         Returns the custom log name
 
-        :return: Lof file name
+        :return: Log file name
         """
-        return f"{self.night}_log.csv"
+        return f"{self.night}_{self.output_name}.csv"
 
     def get_output_path(self) -> Path:
         """

--- a/mirar/processors/database/database_inserter.py
+++ b/mirar/processors/database/database_inserter.py
@@ -47,7 +47,7 @@ class BaseDatabaseInserter(BaseDatabaseProcessor, ABC):
     def __str__(self):
         return (
             f"Processor to save "
-            f"{['candidates', 'images'][isinstance(self, BaseImageProcessor)]} "
+            f"{['sources', 'images'][isinstance(self, BaseImageProcessor)]} "
             f"to the '{self.db_table.__name__}' table of "
             f"the '{self.db_name}' Postgres database."
         )

--- a/mirar/processors/sources/__init__.py
+++ b/mirar/processors/sources/__init__.py
@@ -10,4 +10,10 @@ from mirar.processors.sources.source_detector import ZOGYSourceDetector
 from mirar.processors.sources.source_exporter import SourceWriter
 from mirar.processors.sources.source_filter import BaseSourceFilter
 from mirar.processors.sources.source_loader import SourceLoader
+from mirar.processors.sources.source_selector import (
+    SourceBatcher,
+    SourceDebatcher,
+    SourceRebatcher,
+    SourceSelector,
+)
 from mirar.processors.sources.source_table_modifier import CustomSourceTableModifier

--- a/mirar/processors/sources/forced_photometry.py
+++ b/mirar/processors/sources/forced_photometry.py
@@ -2,13 +2,24 @@
 Module to extract a candidates table from an image header
 """
 
+import logging
+
 import pandas as pd
 
 from mirar.data import ImageBatch, SourceBatch, SourceTable
 from mirar.data.utils import get_xy_from_wcs
 from mirar.errors import ProcessorError
-from mirar.paths import CAND_DEC_KEY, CAND_RA_KEY, XPOS_KEY, YPOS_KEY
+from mirar.paths import (
+    CAND_DEC_KEY,
+    CAND_RA_KEY,
+    SOURCE_HISTORY_KEY,
+    SOURCE_NAME_KEY,
+    XPOS_KEY,
+    YPOS_KEY,
+)
 from mirar.processors.base_processor import BaseSourceGenerator
+
+logger = logging.getLogger(__name__)
 
 
 class TableFromHeaderError(ProcessorError):
@@ -31,11 +42,13 @@ class ForcedPhotometryDetector(BaseSourceGenerator):
         calculate_image_coordinates: bool = True,
         ra_header_key: str = CAND_RA_KEY,
         dec_header_key: str = CAND_DEC_KEY,
+        name_header_key: str | None = None,
     ):
         super().__init__()
         self.calculate_image_coordinates = calculate_image_coordinates
         self.ra_header_key = ra_header_key
         self.dec_header_key = dec_header_key
+        self.name_header_key = name_header_key
 
     def _apply_to_images(self, batch: ImageBatch) -> SourceBatch:
         all_cands = SourceBatch()
@@ -43,9 +56,26 @@ class ForcedPhotometryDetector(BaseSourceGenerator):
             # Save the image here, to facilitate processing downstream
             header = image.get_header()
 
+            metadata = self.get_metadata(image)
+
+            name = None
+
+            if self.name_header_key is not None:
+                try:
+                    name = header[self.name_header_key]
+                except KeyError as exc:
+                    err = (
+                        f"Header key for name ({self.name_header_key}) not "
+                        f"found in header. Available keys: {header.keys()}"
+                    )
+                    logger.error(err)
+                    raise HeaderKeyMissingError(err) from exc
+
             new_dict = {
                 CAND_RA_KEY: image[self.ra_header_key],
                 CAND_DEC_KEY: image[self.dec_header_key],
+                SOURCE_HISTORY_KEY: pd.DataFrame(),
+                SOURCE_NAME_KEY: name,
             }
 
             if self.calculate_image_coordinates:
@@ -58,8 +88,6 @@ class ForcedPhotometryDetector(BaseSourceGenerator):
                 new_dict[YPOS_KEY] = y
 
             src_table = pd.DataFrame([new_dict])
-
-            metadata = self.get_metadata(image)
 
             all_cands.append(SourceTable(src_table, metadata=metadata))
 

--- a/mirar/processors/sources/namer.py
+++ b/mirar/processors/sources/namer.py
@@ -175,7 +175,10 @@ class CandidateNamer(SingleSpatialCrossmatchSource):
 
                     # Insert the name into the source table
                     source[self.name_key] = source_name
-                    new = self.db_table(**source)
+
+                    metadata_dict = self.generate_super_dict(metadata, source)
+
+                    new = self.db_table(**metadata_dict)
                     match = new.insert_entry(
                         duplicate_protocol="fail",
                         returning_key_names=self.db_output_columns,

--- a/mirar/processors/sources/sextractor_source_detector.py
+++ b/mirar/processors/sources/sextractor_source_detector.py
@@ -17,6 +17,8 @@ from mirar.paths import (
     CAND_DEC_KEY,
     CAND_RA_KEY,
     SEXTRACTOR_HEADER_KEY,
+    SOURCE_HISTORY_KEY,
+    SOURCE_NAME_KEY,
     XPOS_KEY,
     YPOS_KEY,
     get_output_dir,
@@ -35,7 +37,10 @@ def generate_candidates_table(
 ) -> pd.DataFrame:
     """
     Generate a candidates table from a sextractor catalog
+
+    :param image: Image object
     :param sextractor_catalog_path: Path to the sextractor catalog
+    :param target_only: Whether to return only the target source
     :return: Candidates table
     """
     det_srcs = get_table_from_ldac(sextractor_catalog_path)
@@ -68,6 +73,8 @@ def generate_candidates_table(
     det_srcs[CAND_DEC_KEY] = det_srcs["DELTAWIN_J2000"]
     det_srcs["fwhm"] = det_srcs["FWHM_IMAGE"]
     det_srcs["elong"] = det_srcs["ELONGATION"]
+    det_srcs[SOURCE_HISTORY_KEY] = pd.DataFrame()
+    det_srcs[SOURCE_NAME_KEY] = None
 
     return det_srcs
 

--- a/mirar/processors/sources/source_detector.py
+++ b/mirar/processors/sources/source_detector.py
@@ -23,6 +23,8 @@ from mirar.paths import (
     REF_IMG_KEY,
     SCI_IMG_KEY,
     SCOR_IMG_KEY,
+    SOURCE_HISTORY_KEY,
+    SOURCE_NAME_KEY,
     XPOS_KEY,
     YPOS_KEY,
     get_output_dir,
@@ -87,6 +89,9 @@ def generate_candidates_table(
     det_srcs = det_srcs[det_srcs["scorr"] > 5]
 
     det_srcs = det_srcs.to_pandas()
+
+    det_srcs[SOURCE_HISTORY_KEY] = [pd.DataFrame() for _ in range(len(det_srcs))]
+    det_srcs[SOURCE_NAME_KEY] = None
 
     logger.debug(
         f"Filtered to {len(det_srcs)} candidates in image with " f"scorr peak > 5."

--- a/mirar/processors/sources/source_selector.py
+++ b/mirar/processors/sources/source_selector.py
@@ -26,7 +26,7 @@ def select_from_sources(
     :param batch: source batch to sort
     :param key: header key to filter on
     :param target_values: accepted value(s) for key
-    :return: source batch containing the subset of images which pass
+    :return: source batch containing the subset of sources which pass
     """
 
     # Enforce string in list for later matching
@@ -50,10 +50,10 @@ def select_from_sources(
 
 class SourceSelector(BaseSourceProcessor, CleanupProcessor):
     """
-    Processor to only select a subset of images from a batch. Images can
+    Processor to only select a subset of sources from a batch. Sources can
     be selected using header keywords. For example, using:
-        ImageSelector(("OBSCLASS", "SCIENCE"))
-    selects Images with header["OBSCLASS"]=="SCIENCE"
+        SourceSelector(("OBSCLASS", "SCIENCE"))
+    selects Sources with header["OBSCLASS"]=="SCIENCE"
     """
 
     base_key = "select"
@@ -70,7 +70,7 @@ class SourceSelector(BaseSourceProcessor, CleanupProcessor):
             else:
                 reqs.append(f"{target[0]} = {target[1]}")
 
-        return f"Processor to select images where {', and '.join(reqs)}"
+        return f"Processor to select sources where {', and '.join(reqs)}"
 
     def _apply_to_sources(
         self,
@@ -88,14 +88,14 @@ def split_sources_into_batches(
     sources: SourceBatch, split_key: str | list[str]
 ) -> Dataset:
     """
-    Function to split a single :class:`~mirar.data.image_data.ImageBatch` object
+    Function to split a single :class:`~mirar.data.source_data.SourceBatch` object
     into multiple :class:`~mirar.data.base_data.DataBatch` objects.
     Each new batch will have the same value of <split_key>.
     Returns a dataset containing the new batches
 
-    :param sources: Image batch to split
+    :param sources: Source batch to split
     :param split_key: Key to split batch
-    :return: Dataset containing new image batches
+    :return: Dataset containing new source batches
     """
 
     if isinstance(split_key, str):
@@ -126,7 +126,7 @@ class SourceBatcher(BaseSourceProcessor):
     Module to split :class:`~mirar.data.source_data.SourceBatch` object
     into multiple :class:`~mirar.data.base_data.DataBatch` objects.
 
-    Images are batched using the `split_key` argument. For example,
+    Sources are batched using the `split_key` argument. For example,
     you can batch by filter, like this:
         SourceBatcher(split_key="filter")
     which will return N batches for the N different filters present
@@ -173,7 +173,7 @@ class SourceBatcher(BaseSourceProcessor):
 
 class SourceDebatcher(BaseSourceProcessor):
     """
-    Processor to group all incoming :class:`~mirar.data.image_data.SourceBatch`
+    Processor to group all incoming :class:`~mirar.data.source_data.SourceBatch`
     objects into a single batch.
     This is helpful if you've already batched at an earlier stage in your workflow, and
     you want to start over and batch by a different split key.
@@ -201,7 +201,7 @@ class SourceDebatcher(BaseSourceProcessor):
 
 class SourceRebatcher(SourceBatcher):
     """
-    Processor to regroup all incoming :class:`~mirar.data.image_data.SourceBatch`
+    Processor to regroup all incoming :class:`~mirar.data.source_data.SourceBatch`
     objects into a single batch, and then split by new keys.
     This is helpful if you've already batched at an earlier stage in your workflow, and
     you want to start over and batch by a different split key.

--- a/mirar/processors/sources/source_selector.py
+++ b/mirar/processors/sources/source_selector.py
@@ -2,6 +2,8 @@
 Module containing processors and functions to select a subset of sources from a batch
 """
 
+# pylint: disable=duplicate-code
+
 import logging
 
 from mirar.data import Dataset, SourceBatch

--- a/mirar/processors/utils/__init__.py
+++ b/mirar/processors/utils/__init__.py
@@ -12,6 +12,7 @@ from mirar.processors.utils.image_saver import ImageSaver
 from mirar.processors.utils.image_selector import (
     ImageBatcher,
     ImageDebatcher,
+    ImageRebatcher,
     ImageSelector,
     select_from_images,
 )


### PR DESCRIPTION
New procedure for names (fix #842): 

1. Namer queries DB for existing names, assigns new names if needed, and puts these into the database. So there are no race conditions, it goes one source at a time.
2.  Next, sources are saved to candidate table. 
3. Candidate table is queried by sourceid for history
4. Source table is updated with averages

The consequence is that source history querying now does not care at all about when candidates are detected, and the detection itself gets returned by this query alongside all other detections. We now strip out this single self-history detection before reaching the avro/skyportal stage.

Other improvements:

* Add SourceBatchers to mirror ImageBatchers
* Add ImageRebatcher/SourceRebatcher, which basically debatches and then batches as normal. (fix #492)
* Introduces core fields for source tables (fix #526)
* Adds option to specify name for log. Means you can create a log for raw images and e.g another for stacks or diffs.