### PR TITLE
Log but remove flats

### DIFF
--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -343,7 +343,7 @@ dark_calibrate = [
         cache_sub_dir="calibration_darks",
         cache_image_name_header_keys=[EXPTIME_KEY, "BOARD_ID"],
     ),
-    ImageSelector((OBSCLASS_KEY, ["science", "flat"])),
+    ImageSelector((OBSCLASS_KEY, ["science"])),
     ImageRebatcher(["BOARD_ID", "UTCTIME", "SUBCOORD"]),
     ImageSaver(output_dir_name="darkcal"),
     CustomImageBatchModifier(winter_dark_oversubtraction_rejector),

--- a/mirar/pipelines/winter/load_winter_image.py
+++ b/mirar/pipelines/winter/load_winter_image.py
@@ -102,6 +102,10 @@ def clean_header(header: fits.Header) -> fits.Header:
         # Set targname to dark
         header["TARGNAME"] = "dark"
 
+    # Tag dome flats as flats
+    if header[OBSCLASS_KEY].lower() == "domeflat":
+        header[OBSCLASS_KEY] = "flat"
+
     header["EXPTIME"] = np.rint(header["EXPTIME"])
 
     # Set up the target name


### PR DESCRIPTION
Testing the optimal flat method is still ongoing. In parallel to that, this PR simply allows the pipeline to parse dome flats as flats (right now they get marked as corrupted) but also removes these flats before processing. So it only affects the logging of flats but not the processing itself.