### PR TITLE
WINTER config for stack of stacks

### DIFF
--- a/mirar/pipelines/winter/winter_pipeline.py
+++ b/mirar/pipelines/winter/winter_pipeline.py
@@ -47,6 +47,7 @@ from mirar.pipelines.winter.blocks import (
     send_to_skyportal,
     stack_dithers,
     stack_forced_photometry,
+    stack_stacks,
     unpack_all,
     unpack_all_no_calhunter,
     unpack_subset,
@@ -120,6 +121,7 @@ class WINTERPipeline(Pipeline):
         + detect_candidates
         + process_candidates
         + avro_broadcast,
+        "stack_stacks": stack_stacks,
         "focus_cals": focus_cals,
         "mosaic": mosaic,
         "log": load_raw + extract_all + csvlog,

--- a/mirar/processors/base_processor.py
+++ b/mirar/processors/base_processor.py
@@ -359,10 +359,17 @@ class ImageHandler:
 
         mask = image.get_mask()
         if LATEST_WEIGHT_SAVE_KEY in image.header:
-            weight_data = self.open_fits(
-                image.header[LATEST_WEIGHT_SAVE_KEY]
-            ).get_data()
-            mask = mask * weight_data
+
+            path = Path(image.header[LATEST_WEIGHT_SAVE_KEY])
+            if path.exists():
+                weight_data = self.open_fits(
+                    image.header[LATEST_WEIGHT_SAVE_KEY]
+                ).get_data()
+                mask = mask * weight_data
+            else:
+                logger.warning(
+                    f"Could not find weight file {image.header[LATEST_WEIGHT_SAVE_KEY]}"
+                )
         self.save_fits(Image(mask.astype(float), header), mask_path)
 
         return mask_path


### PR DESCRIPTION
This PR ads the option for triggering WINTER stack-of-stacks via CLI. Right now it's handy if you use `winterapi` to download a bunch of stacks. You simply put this in the winter data directory, e.g under `S240422ed/final/`, and can then run with:

```bash
python -m mirar -p winter -n S240422ed -c stack_stacks
```

More fancy things will be implemented in #880 and #879 , but this is the first step.