### PR TITLE
Add broadcast status to DB

### DIFF
--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -803,7 +803,7 @@ avro_broadcast = [
     HeaderEditor(edit_keys="sent", values=BROADCAST_BOOL),
     DatabaseSourceInserter(
         db_table=Candidate,
-        duplicate_protocol="fail",
+        duplicate_protocol="replace",
     ),
     SourceWriter(output_dir_name="preskyportal"),
 ]

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -785,6 +785,9 @@ avro_write = [
     ),
 ]
 
+# configure to broadcast to IPAC
+BROADCAST_BOOL = str(os.getenv("BROADCAST_AVRO", None)) in ["True", "t", "1", "true"]
+
 avro_broadcast = [
     # Filter out low quality candidates
     CustomSourceTableModifier(modifier_function=winter_candidate_quality_filterer),
@@ -793,10 +796,14 @@ avro_broadcast = [
         output_sub_dir="avro_ipac",
         topic_prefix="winter",
         base_name="WNTR",
-        # configure to broadcast to IPAC
-        broadcast=str(os.getenv("BROADCAST_AVRO", None)) in ["True", "t", "1", "true"],
+        broadcast=BROADCAST_BOOL,
         save_local=True,
         avro_schema_path=winter_avro_schema_path,
+    ),
+    HeaderEditor(edit_keys="sent", values=BROADCAST_BOOL),
+    DatabaseSourceInserter(
+        db_table=Candidate,
+        duplicate_protocol="fail",
     ),
     SourceWriter(output_dir_name="preskyportal"),
 ]

--- a/mirar/pipelines/winter/models/_candidates.py
+++ b/mirar/pipelines/winter/models/_candidates.py
@@ -59,6 +59,7 @@ class CandidatesTable(WinterBase):  # pylint: disable=too-few-public-methods
     deprecated = Column(Boolean, nullable=False, default=False)
     jd = Column(Float, nullable=False)
     utctime = Column(DateTime(timezone=True))
+    sent = Column(Boolean, nullable=False, default=False)
 
     # Image properties
 
@@ -223,6 +224,8 @@ class Candidate(BaseDB):
 
     jd: float = Field(ge=0)
     utctime: datetime = Field()
+
+    sent: bool = Field(default=False)
 
     diffid: int | None = Field(ge=0, default=None)
     stackid: int = Field(ge=0)


### PR DESCRIPTION
This is a breaking change which adds the field `sent` to the candidates table. Set to False by default, updated to true after the cuts and broadcasting to IPAC.