### PR TITLE
More robust candidate broadcasting

### DIFF
--- a/mirar/catalog/kowalski/base_kowalski_catalog.py
+++ b/mirar/catalog/kowalski/base_kowalski_catalog.py
@@ -20,6 +20,15 @@ class KowalskiError(ProcessorError):
 
 
 PROTOCOL, HOST, PORT = "https", "kowalski.caltech.edu", 443
+KOWALSKI_TIMEOUT = 300.0
+
+kowalski_args = {
+    "protocol": PROTOCOL,
+    "host": HOST,
+    "port": PORT,
+    "verbose": False,
+    "timeout": KOWALSKI_TIMEOUT,
+}
 
 
 def get_kowalski() -> Kowalski:
@@ -34,9 +43,7 @@ def get_kowalski() -> Kowalski:
     if token_kowalski is not None:
         logger.debug("Using kowalski token")
 
-        kowalski_instance = Kowalski(
-            token=token_kowalski, protocol=PROTOCOL, host=HOST, port=PORT
-        )
+        kowalski_instance = Kowalski(token=token_kowalski, **kowalski_args)
 
     else:
         username_kowalski = os.getenv("KOWALSKI_USER")
@@ -61,9 +68,7 @@ def get_kowalski() -> Kowalski:
         kowalski_instance = Kowalski(
             username=username_kowalski,
             password=password_kowalski,
-            protocol=PROTOCOL,
-            host=HOST,
-            port=PORT,
+            **kowalski_args,
         )
 
     if not kowalski_instance.ping():

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -816,6 +816,11 @@ load_skyportal = [SourceLoader(input_dir_name="preskyportal")]
 
 send_to_skyportal = [
     SkyportalCandidateUploader(**winter_fritz_config),
+    HeaderEditor(edit_keys="sent", values=True),
+    DatabaseSourceInserter(
+        db_table=Candidate,
+        duplicate_protocol="replace",
+    ),
 ]
 
 # To make a mosaic by stacking all boards

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -130,7 +130,6 @@ from mirar.processors.sources import (
     CustomSourceTableModifier,
     ForcedPhotometryDetector,
     SourceBatcher,
-    SourceDebatcher,
     SourceLoader,
     SourceWriter,
     ZOGYSourceDetector,
@@ -710,7 +709,6 @@ ml_classify = [
 ]
 
 crossmatch_candidates = [
-    SourceDebatcher(),
     XMatch(catalog=TMASS(num_sources=3, search_radius_arcmin=0.5)),
     XMatch(catalog=PS1(num_sources=3, search_radius_arcmin=0.5)),
     XMatch(catalog=PS1SGSc(num_sources=3, search_radius_arcmin=0.5)),

--- a/mirar/pipelines/winter/blocks.py
+++ b/mirar/pipelines/winter/blocks.py
@@ -812,7 +812,10 @@ process_candidates = ml_classify + crossmatch_candidates + name_candidates + avr
 
 load_avro = [SourceLoader(input_dir_name="preavro")]
 
-load_skyportal = [SourceLoader(input_dir_name="preskyportal")]
+load_skyportal = [
+    SourceLoader(input_dir_name="preskyportal"),
+    SourceBatcher(BASE_NAME_KEY),
+]
 
 send_to_skyportal = [
     SkyportalCandidateUploader(**winter_fritz_config),

--- a/mirar/pipelines/winter/config/__init__.py
+++ b/mirar/pipelines/winter/config/__init__.py
@@ -107,4 +107,17 @@ winter_fritz_config = {
     "stream_id": 1005,
     "update_thumbnails": True,
     "skyportal_client": SkyportalClient(base_url="https://fritz.science/api/"),
+    "annotation_keys": [
+        "rb",
+        "chipsf",
+        "fwhm",
+        "scorr",
+        "nneg",
+        "mindtoedge",
+        "diffmaglim",
+        "distpsnr1",
+        "sgmag1",
+        "srmag1",
+        "simag1",
+    ],
 }

--- a/mirar/processors/skyportal/skyportal_candidate.py
+++ b/mirar/processors/skyportal/skyportal_candidate.py
@@ -67,12 +67,12 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
             )
             logger.error(response.json())
 
-    def skyportal_post_annotation(self, alert):
+    def get_annotations(self, alert) -> dict:
         """
-        Post an annotation. Works for both candidates and sources.
+        Retrieve annotations from alert data.
 
-        :param alert: alert data
-        :return: None
+        :param alert: Alert data
+        :return: Annotations
         """
         data = {}
 
@@ -80,6 +80,16 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
             for key in self.annotation_keys:
                 if key in alert:
                     data[key] = alert[key]
+        return data
+
+    def skyportal_post_annotation(self, alert):
+        """
+        Post an annotation. Works for both candidates and sources.
+
+        :param alert: alert data
+        :return: None
+        """
+        data = self.get_annotations(alert)
 
         payload = {"origin": self.origin, "data": data, "group_ids": self.group_ids}
 
@@ -129,11 +139,7 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
         # annotation from this(WNTR) origin exists
         else:
             # annotation data
-            data = {
-                "fwhm": source["fwhm"],
-                "scorr": source["scorr"],
-                "chipsf": source["chipsf"],
-            }
+            data = self.get_annotations(source)
             new_annotation = {
                 "author_id": existing_annotations[self.origin]["author_id"],
                 "obj_id": source[SOURCE_NAME_KEY],

--- a/mirar/processors/skyportal/skyportal_candidate.py
+++ b/mirar/processors/skyportal/skyportal_candidate.py
@@ -23,11 +23,13 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
         *args,
         stream_id: int,
         fritz_filter_id: int,
+        annotation_keys: list[str] | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.stream_id = stream_id
         self.fritz_filter_id = fritz_filter_id
+        self.annotation_keys = annotation_keys
 
     def skyportal_post_candidate(self, alert):
         """
@@ -74,20 +76,10 @@ class SkyportalCandidateUploader(SkyportalSourceUploader):
         """
         data = {}
 
-        for key in [
-            "chipsf",
-            "fwhm",
-            "scorr",
-            "nneg",
-            "mindtoedge",
-            "diffmaglim",
-            "distpsnr1",
-            "sgmag1",
-            "srmag1",
-            "simag1",
-        ]:
-            if key in alert:
-                data[key] = alert[key]
+        if self.annotation_keys is not None:
+            for key in self.annotation_keys:
+                if key in alert:
+                    data[key] = alert[key]
 
         payload = {"origin": self.origin, "data": data, "group_ids": self.group_ids}
 

--- a/mirar/processors/xmatch.py
+++ b/mirar/processors/xmatch.py
@@ -20,6 +20,8 @@ class XMatch(BaseSourceProcessor):
     Class to cross-match a candidate_table to a catalog
     """
 
+    max_n_cpu = 4
+
     base_key = "XMATCH"
 
     def __init__(


### PR DESCRIPTION
This PR increases robustness/improves fallbacks of candidate broadcasting:

- It extends the timeout window in penquins from default 5s to 600s, for source crossmatching
- It groups sources in batches of 1 for source crossmatching via Kowalski, so that a timeout would affect only a single source table
- It sets a limit of 4 threads for crossmatching API calls, to avoid inadvertent DDOS attacks with 40 threads :sweat_smile:
- It better allows sources to be resent to skyportal via API rather than IPAC. That was possible before, but should now be much closer to normal IPAC-style candidates: annotations are now identical, and all candidates sent via API are marked in the db as sent.
- Adds more flexibility for annotations. Now passed as an argument to skyportal processors, and includes rb score for WINTER. 