### PR TITLE
Broaden WINTER Cal Requirements

### DIFF
--- a/mirar/pipelines/winter/config/__init__.py
+++ b/mirar/pipelines/winter/config/__init__.py
@@ -78,7 +78,15 @@ ref_psfex_path = winter_file_dir.joinpath("reference.psfex")
 
 winter_cal_requirements = [
     CalRequirement(
-        target_name="dark", required_field="EXPTIME", required_values=["120.0"]
+        target_name="dark",
+        required_field="EXPTIME",
+        required_values=[
+            "120.0",  # J/Y
+            "60.0",  # Hs
+            "3.0",  # J flats
+            "4.0",  # Y flats
+            "5.0",  # Hs flats
+        ],
     ),
 ]
 

--- a/mirar/pipelines/winter/generator/candidates.py
+++ b/mirar/pipelines/winter/generator/candidates.py
@@ -277,7 +277,7 @@ def winter_candidate_quality_filterer(source_table: SourceBatch) -> SourceBatch:
     """
     new_batch = []
 
-    min_dist_to_star = 5.0
+    min_dist_to_star = 7.0
 
     for source in source_table:
         src_df = source.get_data()

--- a/mirar/pipelines/winter/winter_pipeline.py
+++ b/mirar/pipelines/winter/winter_pipeline.py
@@ -21,7 +21,6 @@ from mirar.pipelines.winter.blocks import (
     focus_cals,
     full_reduction,
     imsub,
-    load_astrometry,
     load_avro,
     load_calibrated,
     load_final_stack,
@@ -30,14 +29,12 @@ from mirar.pipelines.winter.blocks import (
     load_test,
     mask_and_split,
     mosaic,
-    name_candidates,
     only_ref,
     photcal_stacks,
     plot_stack,
     process_candidates,
     realtime,
     reduce,
-    reduce_no_calhunter,
     reduce_unpacked,
     reduce_unpacked_subset,
     refbuild,
@@ -45,13 +42,10 @@ from mirar.pipelines.winter.blocks import (
     save_raw,
     select_split_subset,
     send_to_skyportal,
-    stack_dithers,
     stack_forced_photometry,
     stack_stacks,
     unpack_all,
-    unpack_all_no_calhunter,
     unpack_subset,
-    unpack_subset_no_calhunter,
 )
 from mirar.pipelines.winter.config import PIPELINE_NAME, winter_cal_requirements
 from mirar.pipelines.winter.load_winter_image import load_raw_winter_mef
@@ -72,14 +66,10 @@ class WINTERPipeline(Pipeline):
         "astrometry": load_calibrated + astrometry,
         "unpack_subset": unpack_subset,
         "unpack_all": unpack_all,
-        "unpack_subset_no_calhunter": unpack_subset_no_calhunter,
-        "unpack_all_no_calhunter": unpack_all_no_calhunter,
         "detrend_unpacked": detrend_unpacked,
         "imsub": load_final_stack + imsub,
         "reduce": reduce,
-        "reduce_no_calhunter": reduce_no_calhunter,
         "reduce_unpacked": reduce_unpacked,
-        "stack": load_astrometry + stack_dithers + photcal_stacks,
         "photcal_stacks": photcal_stacks,
         "plot_stacks": load_final_stack + plot_stack,
         "buildtest": build_test,
@@ -102,27 +92,12 @@ class WINTERPipeline(Pipeline):
         + detect_candidates
         + process_candidates
         + avro_broadcast,
-        "full_imsub": load_final_stack
-        + imsub
-        + detect_candidates
-        + process_candidates
-        + avro_broadcast,
-        "full": reduce
-        + imsub
-        + detect_candidates
-        + process_candidates
-        + avro_broadcast,
         "default": reduce
         + imsub
         + detect_candidates
         + process_candidates
         + avro_broadcast,
-        "full_subset": reduce_unpacked_subset
-        + imsub
-        + detect_candidates
-        + process_candidates
-        + avro_broadcast,
-        "full_no_calhunter": reduce_no_calhunter
+        "default_subset": reduce_unpacked_subset
         + imsub
         + detect_candidates
         + process_candidates
@@ -133,10 +108,8 @@ class WINTERPipeline(Pipeline):
         "mosaic": mosaic,
         "log": load_raw + extract_all + csvlog,
         "skyportal": load_skyportal + send_to_skyportal,
-        "name_candidates": name_candidates,
         "diff_forced_phot": diff_forced_photometry,
         "stack_forced_phot": stack_forced_photometry,
-        "detrend": unpack_all + detrend_unpacked,
         "rebroadcast_avro": load_avro + avro_export,
     }
 

--- a/mirar/processors/utils/cal_hunter.py
+++ b/mirar/processors/utils/cal_hunter.py
@@ -20,6 +20,12 @@ from mirar.processors.utils.image_selector import select_from_images
 logger = logging.getLogger(__name__)
 
 
+class MissingCalibrationsError(ImageNotFoundError):
+    """
+    Error to raise if calibration files are missing
+    """
+
+
 class CalRequirement:
     """
     Class to specify particular calibration files that must be present for processing
@@ -150,7 +156,7 @@ def find_required_cals(
                 if not req.success:
                     err += str(req)
             logger.error(err)
-            raise ImageNotFoundError(err)
+            raise MissingCalibrationsError(err)
 
         dir_to_load = ordered_nights[0].joinpath(subdir)
 


### PR DESCRIPTION
This PR adds in a bunch more darks as required WINTER cals (60s, 5s/4s/3s). It adds a new specific CalHunter error when cals are not found, to help with debugging.

It also reworks the blocks a bit, to put calhunter in the right place and reduce duplication.

It also expands the veto radius for stars to 7".