### PR TITLE
PS1StarGal Vizier catalog

### DIFF
--- a/mirar/catalog/__init__.py
+++ b/mirar/catalog/__init__.py
@@ -6,4 +6,4 @@ The basic structure is contained in :class:`mirar.catalog.base_catalog`
 from mirar.catalog.base.base_catalog import BaseCatalog
 from mirar.catalog.base.catalog_from_file import CatalogFromFile
 from mirar.catalog.multibackend import Gaia2Mass
-from mirar.catalog.vizier.ps1 import PS1
+from mirar.catalog.vizier.ps1 import PS1, PS1StarGal

--- a/mirar/catalog/vizier/__init__.py
+++ b/mirar/catalog/vizier/__init__.py
@@ -3,6 +3,6 @@ Module for catalogs using Vizier
 """
 
 from mirar.catalog.vizier.gaia2mass import Gaia2MassVizier
-from mirar.catalog.vizier.ps1 import PS1
+from mirar.catalog.vizier.ps1 import PS1, PS1StarGal
 from mirar.catalog.vizier.sdss import SDSS, NotInSDSSError, in_sdss
 from mirar.catalog.vizier.skymapper import SkyMapper

--- a/mirar/catalog/vizier/ps1.py
+++ b/mirar/catalog/vizier/ps1.py
@@ -59,3 +59,27 @@ class PS1(VizierCatalog):
             )
             logger.error(err)
             raise NotInPS1Error(err)
+
+
+class PS1StarGal(VizierCatalog):
+    """
+    PanStarrs 1 (PS1) Point Source Catalog (PSC) catalog with Star/Galaxy
+    separation by A. A. Miller & X. J. Hall
+    ref: https://iopscience.iop.org/article/10.1088/1538-3873/abf038
+    """
+
+    catalog_vizier_code = "II/381/hlsp_ps1_mh"
+    abbreviation = "ps1_stargal"
+
+    ra_key = "RAJ2000"
+    dec_key = "DEJ2000"
+
+    @staticmethod
+    def check_coverage(ra_deg: float, dec_deg: float):
+        if not in_ps1(dec_deg):
+            err = (
+                f"Querying for PS1_stargal sources, but the field "
+                f"({ra_deg}, {dec_deg}) was not observed in PS1_stargal."
+            )
+            logger.error(err)
+            raise NotInPS1Error(err)

--- a/mirar/catalog/vizier/ps1.py
+++ b/mirar/catalog/vizier/ps1.py
@@ -87,7 +87,8 @@ class PS1StarGal(VizierCatalog):
 
     def join_query(self, query: dict) -> astropy.table.Table:
         """
-        Join the two queries together
+        Join the two queries (PS1 and PS1_TM catalogs) together,
+        since PS1_TM only has columns {objid, position, psScore}.
 
         :param query:
         :return:

--- a/mirar/pipelines/sedmv2/generator.py
+++ b/mirar/pipelines/sedmv2/generator.py
@@ -89,7 +89,7 @@ def sedmv2_reference_image_generator(image: Image) -> BaseReferenceGenerator:
     Get a reference image generator for an sedmv2 image
 
     For u band: SDSS if possible, otherwise fail
-    For g/r: use PS1
+    For g/r/i/z: use PS1
 
     :param image: image
     :return: Reference image generator

--- a/mirar/pipelines/sedmv2/generator.py
+++ b/mirar/pipelines/sedmv2/generator.py
@@ -194,7 +194,6 @@ def sedmv2_photcal_catalog_purifier(
             sources with nonzero Sextractor FLAGS
             sources with PSF mag = -99
             sources near edge of image
-            sources with large SPREAD_MODEL, (likely galaxies)
         purifies reference catalog by removing:
             sources with 0 reported error
             sources that are likely galaxies according to PS1StarGal 'psScore'
@@ -214,17 +213,6 @@ def sedmv2_photcal_catalog_purifier(
     y_lower_limit = edge_width_pixels
     y_upper_limit = image.get_data().shape[0] - edge_width_pixels
 
-    # remove sources with spread_model > sm_cutoff (they are likely galaxies)
-    sm_cutoff = 0.0015
-    # raise warning if most sources don't pass this cut
-    ind_bad = np.where(sci_catalog["SPREAD_MODEL"] > sm_cutoff)[0]
-    if (len(sci_catalog[ind_bad]) / len(sci_catalog)) > 0.4:
-        logger.warning(
-            f"Many sources with large SPREAD_MODEL value: "
-            f"{len(sci_catalog[ind_bad])} out of {len(sci_catalog)} "
-            f"sources. Likely caused by bad observing conditions."
-        )
-
     good_sci_sources = (
         (sci_catalog["FLAGS"] == 0)
         & (sci_catalog["MAG_PSF"] != 99)
@@ -232,7 +220,6 @@ def sedmv2_photcal_catalog_purifier(
         & (sci_catalog["X_IMAGE"] < x_upper_limit)
         & (sci_catalog["Y_IMAGE"] > y_lower_limit)
         & (sci_catalog["Y_IMAGE"] < y_upper_limit)
-        & (sci_catalog["SPREAD_MODEL"] < sm_cutoff)
     )
 
     logger.debug(

--- a/mirar/pipelines/sedmv2/generator.py
+++ b/mirar/pipelines/sedmv2/generator.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.table import Table
 
 from mirar.catalog import BaseCatalog, Gaia2Mass
-from mirar.catalog.vizier import PS1, SkyMapper
+from mirar.catalog.vizier import PS1StarGal, SkyMapper
 from mirar.catalog.vizier.sdss import SDSS, NotInSDSSError, in_sdss
 from mirar.data.image_data import Image
 from mirar.pipelines.sedmv2.config import (
@@ -51,7 +51,7 @@ def sedmv2_photometric_catalog_generator(image: Image) -> BaseCatalog:
     Generate a photometric calibration catalog for sedmv2 images
 
     For u band: SDSS if possible, otherwise Skymapper (otherwise fail)
-    For g/r1: use PS1
+    For g/r/i/z: use PS1StarGal
 
     :param image: Image
     :return: catalog at image position
@@ -79,7 +79,9 @@ def sedmv2_photometric_catalog_generator(image: Image) -> BaseCatalog:
         err = "U band image is in a field with no reference image."
         logger.error(err)
         raise NotInSDSSError(err)
-    return PS1(min_mag=10, max_mag=20, search_radius_arcmin=5, filter_name=filter_name)
+    return PS1StarGal(
+        min_mag=10, max_mag=20, search_radius_arcmin=5, filter_name=filter_name
+    )
 
 
 def sedmv2_reference_image_generator(image: Image) -> BaseReferenceGenerator:


### PR DESCRIPTION
This PR changes how SEDMv2’s photometry catalog purifier distinguishes galaxies from stars. Instead of using the parameter `SPREAD_MODEL`, which depends highly on the quality of SEDMv2’s observations (on a cloudy night this could flag every source in a field), we now make the star/galaxy distinction in the reference catalog. Specifically, we use the PS1 Point Source Catalog (PSC) catalog by [Y. Tachibana & A. A. Miller](https://iopscience.iop.org/article/10.1088/1538-3873/aae3d9) which includes a column for `psScore` (point source Score). In mirar, the main changes to the code are:
- the new class `PS1StarGal` in catalog/vizier/ps1.py
- updated functions in pipelines/sedmv2/generator.py